### PR TITLE
OEDLayer without sampling in OptimizationExtension

### DIFF
--- a/lib/CorleoneOED/examples/lotka_oed/main.jl
+++ b/lib/CorleoneOED/examples/lotka_oed/main.jl
@@ -164,3 +164,19 @@ uopt = solve(
 # After solving, we now only need to investigate the solution.
 optsol, _ = oed(nothing, uopt + zero(ComponentArray(ps)), st)
 plot_oed(optsol)
+
+
+# ## Sampling-free OED
+
+# If the decisions about when to measure are not degrees of freedom, because, for example,
+# continuous measurement is possible, the OEDLayer can also be constructed without
+# discretizing the measurements. In this case, only the specified controls are degrees of
+# freedom of the optimization.
+
+oed = OEDLayer{false}(
+    prob, Tsit5(),
+    params = [2, 3],
+    controls = (1 => control,),
+    bounds_p = ([1.0, 1.0], [1.0, 1.0]),
+    observed = (u, p, t) -> u[1:2],
+)

--- a/lib/CorleoneOED/ext/CorleoneOEDOptimizationExtension.jl
+++ b/lib/CorleoneOED/ext/CorleoneOEDOptimizationExtension.jl
@@ -92,6 +92,24 @@ function setup_constraints(layer::OEDLayer{<:Any, true, <:Any, <:SingleShootingL
     return sampling_cons
 end
 
+function setup_constraints(layer::OEDLayer{<:Any, false, <:Any, <:SingleShootingLayer}, sol, constraints::Nothing)
+    return nothing
+end
+
+function setup_constraints(layer::OEDLayer{<:Any, false, <:Any, <:MultipleShootingLayer}, sol, constraints::Nothing)
+    ps, st = LuxCore.setup(Random.default_rng(), layer)
+    sampling_cons = let layer = layer, ax = getaxes(ComponentArray(ps))
+        (res, p, st) -> begin
+            ps = ComponentArray(p, ax)
+            sols, _ = layer(nothing, ps, st)
+            shooting = Corleone.shooting_constraints(sols)
+            res .= shooting
+        end
+    end
+    return sampling_cons
+end
+
+
 function setup_constraints(layer::OEDLayer{<:Any, true, <:Any, <:SingleShootingLayer}, sol, constraints)
     ps, st = LuxCore.setup(Random.default_rng(), layer)
     getter_constraints = []
@@ -112,6 +130,30 @@ function setup_constraints(layer::OEDLayer{<:Any, true, <:Any, <:SingleShootingL
             end
 
             res .= vcat(reduce(vcat, cons), sampling)
+        end
+    end
+
+    return sampling_cons
+end
+
+function setup_constraints(layer::OEDLayer{<:Any, false, <:Any, <:SingleShootingLayer}, sol, constraints)
+    ps, st = LuxCore.setup(Random.default_rng(), layer)
+    getter_constraints = []
+    for (k, v) in constraints
+        push!(getter_constraints, getsym(sol, k))
+    end
+
+    sampling_cons = let layer = layer, ax = getaxes(ComponentArray(ps)), getter = getter_constraints, constraints = constraints
+        (res, p, st) -> begin
+            ps = ComponentArray(p, ax)
+            sols, _ = layer(nothing, ps, st)
+            cons = map(enumerate(constraints)) do (i, (k, v))
+                # Caution: timepoints for controls need to be in sols.t!
+                idxs = map(ti -> findfirst(x -> x .== ti, sols.t), v.t)
+                getter[i](sols)[idxs]
+            end
+
+            res .= reduce(vcat, cons)
         end
     end
 
@@ -358,5 +400,51 @@ function Optimization.OptimizationProblem(
         lcons = lcons, ucons = ucons,
     )
 end
+
+function Optimization.OptimizationProblem(
+        layer::OEDLayer{<:Any, false},
+        crit::CorleoneOED.AbstractCriterion;
+        AD::Optimization.ADTypes.AbstractADType = AutoForwardDiff(),
+        u0::ComponentVector = ComponentArray(first(LuxCore.setup(Random.default_rng(), layer))),
+        constraints::Union{Nothing, <:Dict{Any, <:NamedTuple{(:t, :bounds)}}} = nothing,
+        variable_type::Type{T} = Float64,
+        kwargs...
+    ) where {T}
+
+    u0 = T.(u0)
+    check_constraints(layer, constraints)
+
+    # Our objective function
+    ps, st = LuxCore.setup(Random.default_rng(), layer)
+    p = ComponentArray(ps)
+
+    sol, _ = layer(nothing, p, st)
+
+    objective = let layer = layer, ax = getaxes(ComponentArray(ps)), sol = sol
+        (p, st) -> begin
+            ps = ComponentArray(p, ax)
+            first(crit(CorleoneOED.fisher_information(layer, sol, ps, st)[1]))
+        end
+    end
+
+    # Bounds based on the variables
+    lb, ub = Corleone.get_bounds(layer) .|> ComponentArray
+
+    @assert all(lb .<= u0 .<= ub) "The initial variables are not within the bounds. Please check the input!"
+
+    # Constraints
+    cons = setup_constraints(layer, sol, constraints)
+    lcons, ucons = extract_constraint_bounds(layer, constraints, eltype(lb)[])
+
+    # Declare the Optimization function
+    opt_f = OptimizationFunction(objective, AD; cons = cons)
+
+    # Return the optimization problem
+    return OptimizationProblem(
+        opt_f, u0[:], st, lb = lb[:], ub = ub[:],
+        lcons = lcons, ucons = ucons,
+    )
+end
+
 
 end

--- a/lib/CorleoneOED/src/oed.jl
+++ b/lib/CorleoneOED/src/oed.jl
@@ -39,14 +39,14 @@ function Base.show(io::IO, oed::OEDLayer{DISCRETE, SAMPLED, FIXED}) where {DISCR
     type_color, no_color = SciMLBase.get_colorizers(io)
     layer_text = FIXED ? "Fixed " : ""
     preposition = SAMPLED ? "with " : "without "
-    measurement_colot = SAMPLED ? type_color : no_color
+    measurement_color = SAMPLED ? type_color : no_color
     measurement_text = SAMPLED ? (DISCRETE ? "discrete " : "continuous ") : "specified "
     print(
         io,
         no_color, layer_text,
         type_color, "OEDLayer ",
         no_color, preposition,
-        measurement_colot, measurement_text,
+        measurement_color, measurement_text,
         no_color, "measurement model ",
         no_color, "and ", type_color, "$(size(sampling_indices, 1)) ", no_color, "observed functions.\n"
     )

--- a/lib/CorleoneOED/src/oed.jl
+++ b/lib/CorleoneOED/src/oed.jl
@@ -38,12 +38,15 @@ function Base.show(io::IO, oed::OEDLayer{DISCRETE, SAMPLED, FIXED}) where {DISCR
     (; layer, observed, sampling_indices) = oed
     type_color, no_color = SciMLBase.get_colorizers(io)
     layer_text = FIXED ? "Fixed " : ""
-    measurement_text = DISCRETE ? "discrete " : "continuous "
+    preposition = SAMPLED ? "with " : "without "
+    measurement_colot = SAMPLED ? type_color : no_color
+    measurement_text = SAMPLED ? (DISCRETE ? "discrete " : "continuous ") : "specified "
     print(
         io,
         no_color, layer_text,
-        type_color, "OEDLayer ", no_color, "with ",
-        type_color, measurement_text, #"with $(dims.nh) observation functions and $(dims.np_fisher) considered parameters.\n",
+        type_color, "OEDLayer ",
+        no_color, preposition,
+        measurement_colot, measurement_text,
         no_color, "measurement model ",
         no_color, "and ", type_color, "$(size(sampling_indices, 1)) ", no_color, "observed functions.\n"
     )


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The case of OEDLayers without sampling was not covered in the OptimizationExtension. This is now fixed.
