### PR TITLE
Increase size threshold for documentation generation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,7 +22,7 @@ makedocs(
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/Corleone/stable/",
-        size_threshold = 1_000_000,  # bytes
+        size_threshold = 1_500_000,  # bytes
     ),
     #DocumenterVitepress.MarkdownVitepress(
     #    repo = "github.com/SciML/Corleone.jl",


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
