### PR TITLE
ci: add centralized sublibrary downgrade CI

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,0 +1,23 @@
+name: Downgrade Sublibraries
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+jobs:
+  downgrade-sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,Random,Test,Corleone"
+      allow-reresolve: true


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

This adds a new `.github/workflows/DowngradeSublibraries.yml` workflow that runs **downgrade tests for each sublibrary** under `lib/*`. It is a thin one-line caller of the centralized reusable workflow `SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1`, which auto-discovers every `lib/*` package that has a `Project.toml` and, for each, runs `julia-downgrade-compat` + `julia-buildpkg` + `julia-runtest` against `project: lib/<sub>` on the Julia LTS.

Sublibraries covered (auto-discovered):
- `lib/CorleoneOED`
- `lib/OptimalControlBenchmarks`

Both sublibraries dev the in-repo `Corleone` core package via `[sources.Corleone] path = "../.."`, so `Corleone` is excluded from downgrade (we always test against the in-repo version, not a registered older one).

`skip` (deps NOT downgraded):
- Standard libraries: `Pkg`, `TOML`, `Statistics`, `LinearAlgebra`, `SparseArrays`, `InteractiveUtils`, `Random`, `Test`
- In-repo core package: `Corleone`

`allow-reresolve: true` is kept (the reusable workflow default) so the resolver can satisfy transitive constraints when pinning to lowest compatible versions.

Note: this introduces **new required-status-style CI checks** (one job per sublibrary) on pushes/PRs to `main`. The first runs may surface previously-untested lower compat bounds in the sublibraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)