### PR TITLE
ci: add sublibrary test_groups.toml so centralized SublibraryCI runs all groups

### DIFF
--- a/lib/CorleoneOED/test/runtests.jl
+++ b/lib/CorleoneOED/test/runtests.jl
@@ -1,12 +1,21 @@
 using CorleoneOED
 using SafeTestsets
 
-@safetestset "1D Example" begin
-    include("1d_oed.jl")
-end
-@safetestset "Lotka Volterra" begin
-    include("lotka_oed.jl")
-end
-@safetestset "Lotka Volterra SVD" begin
-    include("lotka_oed_svd.jl")
+# Centralized sublibrary CI emits GROUP as the bare package name (-> "Core") or
+# "<pkg>_<grp>" (-> "<grp>"). Map it to the bare section names this file
+# dispatches on. GROUP="All" keeps local `Pkg.test()` runs running everything.
+const _G = get(ENV, "GROUP", "All")
+const _SUB = "CorleoneOED"
+const GROUP = _G == _SUB ? "Core" : (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
+
+if GROUP == "All" || GROUP == "Core"
+    @safetestset "1D Example" begin
+        include("1d_oed.jl")
+    end
+    @safetestset "Lotka Volterra" begin
+        include("lotka_oed.jl")
+    end
+    @safetestset "Lotka Volterra SVD" begin
+        include("lotka_oed_svd.jl")
+    end
 end

--- a/lib/CorleoneOED/test/test_groups.toml
+++ b/lib/CorleoneOED/test/test_groups.toml
@@ -1,0 +1,2 @@
+[Core]
+versions = ["1.11", "lts"]

--- a/lib/OptimalControlBenchmarks/test/runtests.jl
+++ b/lib/OptimalControlBenchmarks/test/runtests.jl
@@ -1,4 +1,13 @@
 using OptimalControlBenchmarks
 using Test
 
-@test 1 == 1
+# Centralized sublibrary CI emits GROUP as the bare package name (-> "Core") or
+# "<pkg>_<grp>" (-> "<grp>"). Map it to the bare section names this file
+# dispatches on. GROUP="All" keeps local `Pkg.test()` runs running everything.
+const _G = get(ENV, "GROUP", "All")
+const _SUB = "OptimalControlBenchmarks"
+const GROUP = _G == _SUB ? "Core" : (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
+
+if GROUP == "All" || GROUP == "Core"
+    @test 1 == 1
+end

--- a/lib/OptimalControlBenchmarks/test/test_groups.toml
+++ b/lib/OptimalControlBenchmarks/test/test_groups.toml
@@ -1,0 +1,2 @@
+[Core]
+versions = ["1.11", "lts"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,28 +1,75 @@
+using Pkg
 using Test
-using JET
 using SafeTestsets
 
-@testset "Corleone.jl" begin
-    @safetestset "Code quality (Aqua.jl)" begin
-        using Aqua
-        using Corleone
-        Aqua.test_all(Corleone)
-    end
-    @safetestset "Local controls" begin
-        include("local_controls.jl")
-    end
-    @safetestset "Multiple shooting" begin
-        include("multiple_shooting.jl")
-    end
-    @testset "Examples" begin
-        @safetestset "Lotka" begin
-            include("examples/lotka_oc.jl")
+const GROUP = get(ENV, "GROUP", "All")
+
+# Centralized sublibrary CI (SciML/.github sublibrary-tests.yml@v1) runs this
+# root test suite with GROUP set to a sublibrary's CI group: the bare sublibrary
+# name selects that sublibrary's "Core" group, and "<sublibrary>_<grp>" selects a
+# named group. Detect those here, activate the sublibrary's own test environment,
+# and hand off to its runtests.jl (which parses GROUP itself). GROUP="All" (the
+# local default) and GROUP="Corleone" run the main-package suite below.
+const LIB_DIR = joinpath(@__DIR__, "..", "lib")
+
+function _detect_sublibrary(group, lib_dir)
+    isdir(joinpath(lib_dir, group)) && return group
+    for i in length(group):-1:1
+        if group[i] == '_' && isdir(joinpath(lib_dir, group[1:(i - 1)]))
+            return group[1:(i - 1)]
         end
-        @safetestset "Lotka MS" begin
-            include("examples/lotka_ms.jl")
+    end
+    return nothing
+end
+
+const _SUBLIB = _detect_sublibrary(GROUP, LIB_DIR)
+
+if _SUBLIB !== nothing
+    sublib_path = joinpath(LIB_DIR, _SUBLIB)
+    Pkg.activate(sublib_path)
+    # On Julia < 1.11 the [sources] table in Project.toml is ignored, so develop
+    # the local path dependencies (e.g. Corleone) to test the PR branch code.
+    if VERSION < v"1.11.0-DEV.0"
+        toml = Pkg.TOML.parsefile(joinpath(sublib_path, "Project.toml"))
+        if haskey(toml, "sources")
+            specs = Pkg.PackageSpec[]
+            for (dep, spec) in toml["sources"]
+                if spec isa Dict && haskey(spec, "path")
+                    dep_path = normpath(joinpath(sublib_path, spec["path"]))
+                    isdir(dep_path) && push!(specs, Pkg.PackageSpec(path = dep_path))
+                end
+            end
+            isempty(specs) || Pkg.develop(specs)
         end
-        @safetestset "Lotka MTK" begin
-            include("examples/mtk.jl")
+    end
+    # Forward GROUP unchanged; the sublibrary runtests.jl parses it.
+    withenv("GROUP" => GROUP) do
+        Pkg.test(_SUBLIB; allow_reresolve = true)
+    end
+else
+    using JET
+    @testset "Corleone.jl" begin
+        @safetestset "Code quality (Aqua.jl)" begin
+            using Aqua
+            using Corleone
+            Aqua.test_all(Corleone)
+        end
+        @safetestset "Local controls" begin
+            include("local_controls.jl")
+        end
+        @safetestset "Multiple shooting" begin
+            include("multiple_shooting.jl")
+        end
+        @testset "Examples" begin
+            @safetestset "Lotka" begin
+                include("examples/lotka_oc.jl")
+            end
+            @safetestset "Lotka MS" begin
+                include("examples/lotka_ms.jl")
+            end
+            @safetestset "Lotka MTK" begin
+                include("examples/mtk.jl")
+            end
         end
     end
 end


### PR DESCRIPTION
## Keep the centralized sublibrary-tests@v1 form; make every group/version actually run

This **keeps** the centralized `SublibraryCI.yml` -> `SciML/.github/.github/workflows/sublibrary-tests.yml@v1` form (that file is untouched) and does **not** restore any bespoke `CI_*.yml`. It fixes the real coverage gap with `test_groups.toml` + a `GROUP` shim, which is the opposite approach to the wrong revert in #72.

### The bug
The reusable workflow runs the **root** test suite with `GROUP` set to a sublibrary's CI group (`<pkg>` for the Core group, `<pkg>_<grp>` for a named group). But the root `test/runtests.jl` had **no `GROUP` dispatch**, so a `GROUP=CorleoneOED` leg silently ran the main-package Corleone suite (Aqua, local controls, multiple shooting, examples) instead of the CorleoneOED tests. Result: the sublibrary legs ran **zero** of their intended tests.

### The fix
- **`test/runtests.jl`**: add a `GROUP` dispatch. When `GROUP` names a `lib/<sub>` (optionally with a `_<grp>` suffix), activate that sublibrary's test env, develop its local `[sources]` path deps on Julia < 1.11, and run `Pkg.test(<sub>)` forwarding `GROUP`. `GROUP="All"` (local default) and `GROUP="Corleone"` run the main Corleone suite as before.
- **`lib/CorleoneOED/test/test_groups.toml`**: `[Core] versions = ["1.11", "lts"]` — encoding exactly what the old bespoke `CI.yml` ran for the `CorleoneOED` group (no macOS/GPU legs, no `JULIA_NUM_THREADS` in the old CI).
- **`lib/OptimalControlBenchmarks/test/test_groups.toml`**: `[Core] versions = ["1.11", "lts"]`.
- **Each sublibrary `test/runtests.jl`**: add the standard GROUP-parsing shim so `GROUP="<pkg>"` -> `Core` and `GROUP="<pkg>_<grp>"` -> `<grp>` drives the existing dispatch; `"All"` still runs everything locally.

### Encoded groups
| sublibrary | group | versions | runner | threads |
|---|---|---|---|---|
| CorleoneOED | Core | 1.11, lts | ubuntu-latest | 1 |
| OptimalControlBenchmarks | Core | 1.11, lts | ubuntu-latest | 1 |

### Verification (no heavy suite run)
Ran `SciML/.github` `compute_affected_sublibraries.jl` against this tree:
- change to `lib/CorleoneOED/src` -> matrix `CorleoneOED` on `1.11` and `lts`
- change to `lib/OptimalControlBenchmarks/src` -> matrix `OptimalControlBenchmarks` on `1.11` and `lts`

Simulating each emitted `GROUP` through the root `_detect_sublibrary` + the sublibrary shim:
- `GROUP=CorleoneOED` -> activate `lib/CorleoneOED`, parsed group `Core` -> runs `1D Example`, `Lotka Volterra`, `Lotka Volterra SVD`
- `GROUP=OptimalControlBenchmarks` -> activate `lib/OptimalControlBenchmarks`, parsed `Core` -> runs its test
- `GROUP=All`/`Corleone` -> root Corleone main suite

Every group the matrix emits maps to a real, non-empty test selection. Sublibraries remain change-gated by design (only run on `lib/*` changes), which is intended.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)