### PR TITLE
ci: standardize sublibrary test groups to Core/QA (fold custom groups)

### DIFF
--- a/lib/CorleoneOED/test/runtests.jl
+++ b/lib/CorleoneOED/test/runtests.jl
@@ -2,8 +2,8 @@ using CorleoneOED
 using SafeTestsets
 
 # Centralized sublibrary CI emits GROUP as the bare package name (-> "Core") or
-# "<pkg>_<grp>" (-> "<grp>"). Map it to the bare section names this file
-# dispatches on. GROUP="All" keeps local `Pkg.test()` runs running everything.
+# "<pkg>_<grp>" (-> "<grp>"). Map it to the standard Core/QA section names this
+# file dispatches on. GROUP="All" keeps local `Pkg.test()` runs running everything.
 const _G = get(ENV, "GROUP", "All")
 const _SUB = "CorleoneOED"
 const GROUP = _G == _SUB ? "Core" : (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
@@ -17,5 +17,13 @@ if GROUP == "All" || GROUP == "Core"
     end
     @safetestset "Lotka Volterra SVD" begin
         include("lotka_oed_svd.jl")
+    end
+end
+
+if GROUP == "All" || GROUP == "QA"
+    @safetestset "Code quality (Aqua.jl)" begin
+        using Aqua
+        using CorleoneOED
+        Aqua.test_all(CorleoneOED)
     end
 end

--- a/lib/CorleoneOED/test/test_groups.toml
+++ b/lib/CorleoneOED/test/test_groups.toml
@@ -1,2 +1,0 @@
-[Core]
-versions = ["1.11", "lts"]

--- a/lib/OptimalControlBenchmarks/test/runtests.jl
+++ b/lib/OptimalControlBenchmarks/test/runtests.jl
@@ -1,13 +1,22 @@
 using OptimalControlBenchmarks
 using Test
+using SafeTestsets
 
 # Centralized sublibrary CI emits GROUP as the bare package name (-> "Core") or
-# "<pkg>_<grp>" (-> "<grp>"). Map it to the bare section names this file
-# dispatches on. GROUP="All" keeps local `Pkg.test()` runs running everything.
+# "<pkg>_<grp>" (-> "<grp>"). Map it to the standard Core/QA section names this
+# file dispatches on. GROUP="All" keeps local `Pkg.test()` runs running everything.
 const _G = get(ENV, "GROUP", "All")
 const _SUB = "OptimalControlBenchmarks"
 const GROUP = _G == _SUB ? "Core" : (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
 
 if GROUP == "All" || GROUP == "Core"
     @test 1 == 1
+end
+
+if GROUP == "All" || GROUP == "QA"
+    @safetestset "Code quality (Aqua.jl)" begin
+        using Aqua
+        using OptimalControlBenchmarks
+        Aqua.test_all(OptimalControlBenchmarks)
+    end
 end

--- a/lib/OptimalControlBenchmarks/test/test_groups.toml
+++ b/lib/OptimalControlBenchmarks/test/test_groups.toml
@@ -1,2 +1,0 @@
-[Core]
-versions = ["1.11", "lts"]


### PR DESCRIPTION
## Standardize sublibrary CI to the SciML Core/QA test groups

This is the follow-up to #73 (merged). #73 correctly **kept** the centralized
`SublibraryCI.yml` -> `SciML/.github` `sublibrary-tests.yml@v1` form, but it
preserved the old bespoke behavior as non-standard `test_groups.toml` sections:
a single `[Core]` with a narrowed `versions = ["1.11", "lts"]` matrix and **no
QA leg at all**. The maintainer wants the standard Core/QA groups, folding the
custom one in.

### What standard means here
Confirmed against the OrdinaryDiffEq sublibraries (24x Core, 26x QA, 8x GPU):
- **Core** = all functional/correctness tests (default-on).
- **QA** = Aqua/JET/ExplicitImports/alloc.
- **GPU** = GPU tests; requires a `[GPU]` `test_groups.toml` runner section.

Both sublibraries here are small, have no GPU tests, and need no isolated test
env or extended timeout, so the standard fix is to **delete `test_groups.toml`
entirely** and let the reusable workflow's defaults apply.

### Changes
- **Delete `lib/CorleoneOED/test/test_groups.toml`** and
  **`lib/OptimalControlBenchmarks/test/test_groups.toml`**. With no
  `test_groups.toml`, `compute_affected_sublibraries.jl` emits the standard
  default matrix: `Core` on `[lts, 1.11, 1, pre]` and `QA` on `[1]`.
- **`lib/CorleoneOED/test/runtests.jl`** and
  **`lib/OptimalControlBenchmarks/test/runtests.jl`**: keep the GROUP
  prefix-strip shim and dispatch on the parsed standard group:
  - `Core` (+`All`) runs the functional tests (folds the old `[Core]`).
  - `QA` (+`All`) runs `Aqua.test_all`. Aqua was already a declared test dep
    (`[extras]`/`[targets].test`/`[compat]`) but was never actually run; this
    folds it into the standard QA group.
  - `All` (local `Pkg.test()` default) still runs everything.

Only `Core`/`QA` group names remain. No `[GPU]` section is added (no GPU tests).
`SublibraryCI.yml` is untouched; no bespoke `CI_*.yml` is restored.

### Emitted matrix (verified with `SciML/.github` `compute_affected_sublibraries.jl@v1`)
Change to `lib/CorleoneOED/src`:
```
CorleoneOED on lts, 1.11, 1, pre   (Core)
CorleoneOED_QA on 1                 (QA)
```
Change to `lib/OptimalControlBenchmarks/src`: same shape with the
`OptimalControlBenchmarks` prefix.

### GROUP dispatch verification (no heavy suite run)
Simulating the shim + dispatch for each emitted GROUP:
- `GROUP=CorleoneOED` -> parsed `Core` -> `@safetestset "1D Example"`,
  `"Lotka Volterra"`, `"Lotka Volterra SVD"`.
- `GROUP=CorleoneOED_QA` -> parsed `QA` -> `@safetestset "Code quality (Aqua.jl)"`.
- `GROUP=OptimalControlBenchmarks` -> parsed `Core` -> `@test 1 == 1`.
- `GROUP=OptimalControlBenchmarks_QA` -> parsed `QA` -> `@safetestset "Code quality (Aqua.jl)"`.
- `GROUP=All` -> both Core and QA blocks.

The union of Core+QA covers every functional test the old `[Core]` ran (nothing
lost) and additionally enables the previously-dormant Aqua QA leg.

### macOS / GPU note
The standard sublibrary CI is ubuntu (Core/QA) + a gpu-runner (GPU only); it
does not use macOS. These sublibraries never had macOS or GPU CI legs (verified
in git history), so none were dropped.

### Tradeoff
The standard default Core matrix is wider than the old `["1.11", "lts"]` (it
adds `1` and `pre`). This is the intended SciML default; `pre` failures on a
pre-release Julia can be excluded later via the reusable workflow's `EXCLUDES`
if they prove flaky, as is done for some OrdinaryDiffEq groups.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)