### PR TITLE
ci: align Corleone sublibrary dispatch to OrdinaryDiffEq canonical pattern

### DIFF
--- a/lib/CorleoneOED/test/runtests.jl
+++ b/lib/CorleoneOED/test/runtests.jl
@@ -1,12 +1,7 @@
 using CorleoneOED
 using SafeTestsets
 
-# Centralized sublibrary CI emits GROUP as the bare package name (-> "Core") or
-# "<pkg>_<grp>" (-> "<grp>"). Map it to the standard Core/QA section names this
-# file dispatches on. GROUP="All" keeps local `Pkg.test()` runs running everything.
-const _G = get(ENV, "GROUP", "All")
-const _SUB = "CorleoneOED"
-const GROUP = _G == _SUB ? "Core" : (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
+const GROUP = get(ENV, "CORLEONE_TEST_GROUP", "All")
 
 if GROUP == "All" || GROUP == "Core"
     @safetestset "1D Example" begin

--- a/lib/OptimalControlBenchmarks/test/runtests.jl
+++ b/lib/OptimalControlBenchmarks/test/runtests.jl
@@ -2,12 +2,7 @@ using OptimalControlBenchmarks
 using Test
 using SafeTestsets
 
-# Centralized sublibrary CI emits GROUP as the bare package name (-> "Core") or
-# "<pkg>_<grp>" (-> "<grp>"). Map it to the standard Core/QA section names this
-# file dispatches on. GROUP="All" keeps local `Pkg.test()` runs running everything.
-const _G = get(ENV, "GROUP", "All")
-const _SUB = "OptimalControlBenchmarks"
-const GROUP = _G == _SUB ? "Core" : (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
+const GROUP = get(ENV, "CORLEONE_TEST_GROUP", "All")
 
 if GROUP == "All" || GROUP == "Core"
     @test 1 == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,47 +4,71 @@ using SafeTestsets
 
 const GROUP = get(ENV, "GROUP", "All")
 
-# Centralized sublibrary CI (SciML/.github sublibrary-tests.yml@v1) runs this
-# root test suite with GROUP set to a sublibrary's CI group: the bare sublibrary
-# name selects that sublibrary's "Core" group, and "<sublibrary>_<grp>" selects a
-# named group. Detect those here, activate the sublibrary's own test environment,
-# and hand off to its runtests.jl (which parses GROUP itself). GROUP="All" (the
-# local default) and GROUP="Corleone" run the main-package suite below.
-const LIB_DIR = joinpath(@__DIR__, "..", "lib")
+# Detect sublibrary test groups.
+# GROUP can be a bare sublibrary name (Core test group) or
+# "{sublibrary}_{TEST_GROUP}" for any custom group (e.g., QA, GPU, etc.).
+# Sublibraries declare their groups in test/test_groups.toml.
+const _LIB_DIR = joinpath(dirname(@__DIR__), "lib")
 
-function _detect_sublibrary(group, lib_dir)
-    isdir(joinpath(lib_dir, group)) && return group
+# Check if GROUP matches a sublibrary, possibly with a _SUFFIX for the test group.
+# Scan underscores right-to-left to find the longest matching sublibrary prefix.
+function _detect_sublibrary_group(group, lib_dir)
+    isdir(joinpath(lib_dir, group)) && return (group, "Core")
     for i in length(group):-1:1
         if group[i] == '_' && isdir(joinpath(lib_dir, group[1:(i - 1)]))
-            return group[1:(i - 1)]
+            return (group[1:(i - 1)], group[(i + 1):end])
         end
     end
-    return nothing
+    return (group, "Core")
 end
+base_group, test_group = _detect_sublibrary_group(GROUP, _LIB_DIR)
 
-const _SUBLIB = _detect_sublibrary(GROUP, LIB_DIR)
-
-if _SUBLIB !== nothing
-    sublib_path = joinpath(LIB_DIR, _SUBLIB)
-    Pkg.activate(sublib_path)
-    # On Julia < 1.11 the [sources] table in Project.toml is ignored, so develop
-    # the local path dependencies (e.g. Corleone) to test the PR branch code.
+if isdir(joinpath(_LIB_DIR, base_group))
+    Pkg.activate(joinpath(_LIB_DIR, base_group))
+    # On Julia < 1.11, the [sources] section in Project.toml is not supported.
+    # Manually Pkg.develop local path dependencies so CI tests the PR branch code.
+    # We resolve transitively: each developed dependency's own [sources] are also
+    # developed, so that packages like OrdinaryDiffEqRosenbrockTableaus (a source
+    # dependency of OrdinaryDiffEqRosenbrock) are correctly found even when testing
+    # a higher-level sublibrary like OrdinaryDiffEqDefault.
     if VERSION < v"1.11.0-DEV.0"
-        toml = Pkg.TOML.parsefile(joinpath(sublib_path, "Project.toml"))
-        if haskey(toml, "sources")
-            specs = Pkg.PackageSpec[]
-            for (dep, spec) in toml["sources"]
-                if spec isa Dict && haskey(spec, "path")
-                    dep_path = normpath(joinpath(sublib_path, spec["path"]))
-                    isdir(dep_path) && push!(specs, Pkg.PackageSpec(path = dep_path))
+        developed = Set{String}()
+        # Never develop the active project: when sublibraries cyclically
+        # reference each other via [sources] (e.g. DiffEqDevTools points
+        # back at OrdinaryDiffEqCore), the transitive walk below would
+        # otherwise try to `Pkg.develop` the active project itself, which
+        # Pkg refuses with "package <X> has the same name or UUID as the
+        # active project".
+        push!(developed, normpath(joinpath(_LIB_DIR, base_group)))
+        specs = Pkg.PackageSpec[]
+        queue = [joinpath(_LIB_DIR, base_group)]
+        while !isempty(queue)
+            pkg_dir = popfirst!(queue)
+            toml_path = joinpath(pkg_dir, "Project.toml")
+            isfile(toml_path) || continue
+            toml = Pkg.TOML.parsefile(toml_path)
+            if haskey(toml, "sources")
+                for (dep_name, source_spec) in toml["sources"]
+                    if source_spec isa Dict && haskey(source_spec, "path")
+                        dep_path = normpath(joinpath(pkg_dir, source_spec["path"]))
+                        if isdir(dep_path) && !(dep_path in developed)
+                            push!(developed, dep_path)
+                            @info "Queuing local source dependency" dep_name dep_path
+                            push!(specs, Pkg.PackageSpec(path = dep_path))
+                            # Queue this dependency so its own [sources] are also resolved.
+                            push!(queue, dep_path)
+                        end
+                    end
                 end
             end
-            isempty(specs) || Pkg.develop(specs)
         end
+        # Batch the develop call so Pkg resolves all path deps together;
+        # calling it one-at-a-time would re-resolve the active project and
+        # fail to find unregistered siblings.
+        isempty(specs) || Pkg.develop(specs)
     end
-    # Forward GROUP unchanged; the sublibrary runtests.jl parses it.
-    withenv("GROUP" => GROUP) do
-        Pkg.test(_SUBLIB; allow_reresolve = true)
+    withenv("CORLEONE_TEST_GROUP" => test_group) do
+        Pkg.test(base_group; julia_args = ["--check-bounds=auto", "--depwarn=yes"], force_latest_compatible_version = false, allow_reresolve = true)
     end
 else
     using JET


### PR DESCRIPTION
Aligns Corleone's sublibrary test dispatch to the **OrdinaryDiffEq canonical pattern**.

#73 (merged) routed sublibrary tests by **forwarding the raw `GROUP`** to each sublibrary and re-parsing it there with a per-sublibrary `_SUB`/`startswith` prefix-strip shim. The canonical pattern instead has the **root `test/runtests.jl` translate** the emitted `GROUP` (`<pkg>` → Core, `<pkg>_<section>`) into a clean `CORLEONE_TEST_GROUP` env var and `Pkg.test()` the sublibrary; each sublibrary `runtests.jl` then just does `get(ENV, "CORLEONE_TEST_GROUP", "All")` — no shim.

- `test/runtests.jl`: `_detect_sublibrary_group` returns `(base, section)`; activates `lib/<base>`, sets `CORLEONE_TEST_GROUP=<section>`, `Pkg.test(<base>)`. Main-package suite unchanged in the `else` branch.
- `lib/CorleoneOED/test/runtests.jl`, `lib/OptimalControlBenchmarks/test/runtests.jl`: read `CORLEONE_TEST_GROUP`; Core runs functional, QA runs `Aqua.test_all`.

This is the same form as BVP #497 and NonlinearSolve #953. Supersedes the dispatch in #73 (which is already merged). Please ignore until reviewed by @ChrisRackauckas.
