### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,27 +15,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 jobs:
   tests:
-    name: "${{ matrix.group }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-          - Examples
-          - QA
-        version:
-          - 'lts'
-          - '1'
-          - 'pre'
-        exclude:
-          # QA (Aqua) runs on lts + current release only, not pre.
-          - group: QA
-            version: 'pre'
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
-      group-env-name: "GROUP"
       check-bounds: "auto"
       coverage-directories: "src"
     secrets: "inherit"


### PR DESCRIPTION
## Summary

Simplifies the **root** test workflow (`.github/workflows/CI.yml`, status-check name `CI`) from a hand-maintained `group × version` matrix that called `tests.yml@v1` into a thin caller of the centralized `grouped-tests.yml@v1`. The matrix now lives entirely in the already-present `test/test_groups.toml`.

The root test job becomes:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    with:
      check-bounds: "auto"
      coverage-directories: "src"
    secrets: "inherit"
```

- `check-bounds: auto` and `coverage-directories: src` are carried over because they differ from the workflow defaults (`yes` / `src,ext`).
- `group-env-name` is omitted: the root `test/runtests.jl` reads `GROUP` (the default), via `const GROUP = get(ENV, "GROUP", "All")`.
- The existing `on:` triggers and `concurrency:` block are preserved verbatim, and the `name: CI` is unchanged so the branch-protection status check name is preserved.
- `SublibraryCI.yml` (which calls `sublibrary-project-tests.yml@v1`) is left untouched, as are all other workflows.

## Verified matrix match

Ran `scripts/compute_affected_sublibraries.jl . --root-matrix` from `SciML/.github@v1` against `test/test_groups.toml`. It emits exactly the 8 (group, version) pairs the old embedded matrix ran:

| group | versions |
|-------|----------|
| Core | lts, 1, pre |
| Examples | lts, 1, pre |
| QA | lts, 1 |

That is **8/8 exact** — the old matrix was `{Core, Examples, QA} × {lts, 1, pre}` with `exclude: {QA, pre}` = 8 pairs. No missing or extra entries. All groups run on the default `ubuntu-latest`, single-threaded, 120 min timeout, with `continue_on_error = false` (no per-group specials in the old workflow). TOML and YAML both parse cleanly.

Ignore until reviewed by @ChrisRackauckas.