### PR TITLE
test: route empty/All GROUP to Core in runtests dispatch (fix Pkg.test("") on downgrade)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,9 +35,15 @@ function activate_examples_env()
     return Pkg.instantiate()
 end
 
+# Reserved main-suite group names: these route to the main-package branch below,
+# never to a sublibrary, even if a lib/<name> directory happened to match.
+const _RESERVED_GROUPS = ("All", "Core", "Examples", "QA")
+
 # Scan underscores right-to-left to find the longest matching sublibrary prefix,
-# returning (sublibrary, test_group) where test_group defaults to "Core".
+# returning (sublibrary, test_group) where test_group defaults to "Core". An empty
+# or reserved GROUP is never a sublibrary (an empty name would match lib/ itself).
 function _detect_sublibrary_group(group, lib_dir)
+    (isempty(group) || group in _RESERVED_GROUPS) && return (group, "Core")
     isdir(joinpath(lib_dir, group)) && return (group, "Core")
     for i in length(group):-1:1
         if group[i] == '_' && isdir(joinpath(lib_dir, group[1:(i - 1)]))
@@ -49,7 +55,7 @@ end
 
 const _SUBLIB, _SUB_GROUP = _detect_sublibrary_group(GROUP, LIB_DIR)
 
-if isdir(joinpath(LIB_DIR, _SUBLIB))
+if !isempty(_SUBLIB) && !(_SUBLIB in _RESERVED_GROUPS) && isdir(joinpath(LIB_DIR, _SUBLIB))
     sublib_path = joinpath(LIB_DIR, _SUBLIB)
     Pkg.activate(sublib_path)
     # On Julia < 1.11 the [sources] table in Project.toml is ignored, so develop


### PR DESCRIPTION
## Problem

`test/runtests.jl`'s grouped-tests dispatcher mis-routes when `GROUP` is the empty string `""` — which the centralized downgrade caller (SciML `.github` downgrade workflow) passes.

The dispatcher decided "is `GROUP` a sublibrary?" via `isdir(joinpath(LIB_DIR, GROUP))`. For `GROUP=""`, `joinpath(LIB_DIR, "")` resolves to `lib/`, which **exists**, so the code wrongly entered the sublibrary branch and called `Pkg.test("")`:

```
ERROR: The following package names could not be resolved:
 *  (not found in project or manifest)
```

This is a test-harness **dispatch** bug introduced by the grouped-tests conversion — not a test-logic problem.

## Fix

Guard the sublibrary dispatch so an empty or reserved-name `GROUP` is never treated as a sublibrary and falls through to the main-package (Core) branch:

- Added `const _RESERVED_GROUPS = ("All", "Core", "Examples", "QA")`.
- `_detect_sublibrary_group` now short-circuits to `(group, "Core")` for empty/reserved group names before the `isdir` check.
- The dispatch condition is now `!isempty(_SUBLIB) && !(_SUBLIB in _RESERVED_GROUPS) && isdir(joinpath(LIB_DIR, _SUBLIB))`.

No test logic or assertions are changed — only the GROUP-dispatch guard.

## Verification (local, Julia 1.11.9)

**Before (upstream `test/runtests.jl`), `GROUP=""`:**
```
  Activating new project at `/lib`
ERROR: LoadError: The following package names could not be resolved:
 *  (not found in project or manifest)
  ... Pkg.test ... runtests.jl:86
exit 1
```

**After (this PR), `GROUP=""`:**
```
Test Summary: | Total  Time
Corleone.jl   |     0  0.0s
exit 0
```
The empty-GROUP run now enters the Core/main-suite `else` branch (confirmed via a transient probe showing `GROUP=""`, `_SUBLIB=""` hitting the Core branch; probe removed before commit) and no longer calls `Pkg.test("")`.

Dispatch routing table (verified): `""`, `All`, `Core`, `Examples`, `QA` → Core/main-suite; `CorleoneOED` → sublibrary (group `Core`); `CorleoneOED_QA` → sublibrary `CorleoneOED` (group `QA`); `OptimalControlBenchmarks` → sublibrary. So real sublibrary routing (including the `_`-suffix group form) is unchanged.

`GROUP="Core"` was also confirmed to still route into the real Core safetestsets (`Local controls`, `Multiple shooting`); the only errors observed there were unrelated environment/instantiation failures (`Package Reexport ... not installed`) in this un-instantiated fresh clone, not dispatch.

---

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)