### PR TITLE
Bump sublibrary Corleone compat 0.0.3 -> 0.0.4 to match released parent

### DIFF
--- a/lib/CorleoneOED/Project.toml
+++ b/lib/CorleoneOED/Project.toml
@@ -27,7 +27,7 @@ CorleoneOEDOptimizationExtension = ["Optimization", "ComponentArrays"]
 CorleoneOEDZygoteExtension = "Zygote"
 
 [compat]
-Corleone = "0.0.3"
+Corleone = "0.0.4"
 ComponentArrays = "0.15"
 DocStringExtensions = "0.9"
 ForwardDiff = "1.3"

--- a/lib/CorleoneOED/test/qa/Project.toml
+++ b/lib/CorleoneOED/test/qa/Project.toml
@@ -10,7 +10,7 @@ CorleoneOED = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-Corleone = "0.0.3"
+Corleone = "0.0.4"
 CorleoneOED = "0.0.4"
 Test = "1"
 julia = "1.10"

--- a/lib/OptimalControlBenchmarks/Project.toml
+++ b/lib/OptimalControlBenchmarks/Project.toml
@@ -33,7 +33,7 @@ UnoSolver = "1baa60ac-02f7-4b39-a7a8-2f4f58486b05"
 
 [compat]
 ComponentArrays = "0.15"
-Corleone = "0.0.3"
+Corleone = "0.0.4"
 DocStringExtensions = "0.9"
 ForwardDiff = "1.3"
 Ipopt = "1"

--- a/lib/OptimalControlBenchmarks/test/qa/Project.toml
+++ b/lib/OptimalControlBenchmarks/test/qa/Project.toml
@@ -10,7 +10,7 @@ OptimalControlBenchmarks = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-Corleone = "0.0.3"
+Corleone = "0.0.4"
 OptimalControlBenchmarks = "0.0.3"
 Test = "1"
 julia = "1.10"

--- a/test/examples/Project.toml
+++ b/test/examples/Project.toml
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ComponentArrays = "0.15"
-Corleone = "0.0.3"
+Corleone = "0.0.4"
 ForwardDiff = "1.2"
 Ipopt = "1.10"
 LuxCore = "1.4"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -10,7 +10,7 @@ Corleone = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-Corleone = "0.0.3"
+Corleone = "0.0.4"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1"
 Test = "1"


### PR DESCRIPTION
## Problem

The `downgrade-sublibraries` master lanes for `lib/CorleoneOED` and `lib/OptimalControlBenchmarks` are red. Both fail during the test-sandbox resolve (before any test code runs) with:

```
ERROR: LoadError: empty intersection between Corleone@0.0.4 and project compatibility 0.0.3
```

## Root cause

PR #100 ("Release v0.0.4") bumped the parent `Corleone` `version` from 0.0.3 to 0.0.4 but did **not** update the sublibraries' `Corleone` `[compat]`, which still pinned `"0.0.3"`. For pre-1.0 versions the caret range `"0.0.3"` means `[0.0.3, 0.0.4)`, which excludes 0.0.4. The sublibraries consume the parent via `[sources.Corleone] path = "../.."`, so the path-sourced parent resolves at 0.0.4 and has an empty intersection with the compat ceiling.

On Julia 1.10 (lts, the downgrade lane's channel) the `[sources]` table is ignored and the parent is `develop`'d by path at 0.0.4, so the conflict is unavoidable until compat admits 0.0.4.

## Fix

Bump `Corleone = "0.0.4"` in:
- `lib/CorleoneOED/Project.toml`
- `lib/OptimalControlBenchmarks/Project.toml`

and, to keep the QA/Examples lanes from inheriting the same wall, in the path-sourcing test sub-projects:
- `lib/CorleoneOED/test/qa/Project.toml`
- `lib/OptimalControlBenchmarks/test/qa/Project.toml`
- `test/qa/Project.toml`
- `test/examples/Project.toml`

Pure `[compat]` change; no `.jl` touched.

## Verification

Reproduced the exact `empty intersection` from the failing run (job 82863923402 / 82863923404). Verified locally on Julia 1.10 that with the bumped compat the sublibrary test sandbox resolves and the Core group runs (OptimalControlBenchmarks Core is a trivial `@test 1 == 1` that only depends on the sandbox resolving).

---

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)