### PR TITLE
QA: run_qa v1.6 form + ExplicitImports (root + sublibs)

### DIFF
--- a/lib/CorleoneOED/test/qa/Project.toml
+++ b/lib/CorleoneOED/test/qa/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Corleone = "2751e0db-33e9-4374-b36d-b7219e1e6b40"
 CorleoneOED = "6590a4b1-d036-41fe-a5b4-03a980244101"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -12,5 +13,6 @@ CorleoneOED = {path = "../.."}
 Aqua = "0.8"
 Corleone = "0.0.5"
 CorleoneOED = "0.0.5"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/lib/CorleoneOED/test/qa/qa.jl
+++ b/lib/CorleoneOED/test/qa/qa.jl
@@ -10,18 +10,20 @@ run_qa(
     # explicit import is a sizable refactor tracked in SciML/Corleone.jl#103.
     ei_broken = (:no_implicit_imports,),
     ei_kwargs = (;
-        # Deliberate uses of internal names that are not (yet) declared public in
-        # their owning modules: Base/stdlib internals, SciML internals, and
-        # Corleone's own as-yet-unexported helpers reached through `Corleone.*`.
+        # Names still not declared public in their owning modules: SciMLBase
+        # internals (`AbstractDEAlgorithm`, `AbstractDEProblem`, `get_colorizers`),
+        # SciMLStructures internals (`Tunable`, `canonicalize`), SymbolicUtils
+        # internal (`Code`), Symbolics internals (`getdefaultval`, `setdefaultval`,
+        # `variables`), ForwardDiff internal (`jacobian`), and Corleone's own
+        # as-yet-unexported helpers reached through `Corleone.*`.
         all_qualified_accesses_are_public = (;
             ignore = (
-                :AbstractDEAlgorithm, :AbstractDEProblem, :Code, :Fix1, :Fix2,
-                :Tunable, :build_index_grid, :canonicalize, :front,
-                :get_block_structure, :get_bounds, :get_colorizers,
+                :AbstractDEAlgorithm, :AbstractDEProblem, :Code, :Tunable,
+                :build_index_grid, :canonicalize, :get_block_structure,
+                :get_bounds, :get_colorizers,
                 :get_number_of_shooting_constraints, :get_timegrid, :getdefaultval,
-                :initialparameters, :initialstates, :jacobian,
-                :retrieve_symbol_cache, :setdefaultval, :shooting_constraints,
-                :shooting_constraints!, :variable, :variables,
+                :jacobian, :retrieve_symbol_cache, :setdefaultval,
+                :shooting_constraints, :shooting_constraints!, :variables,
             ),
         ),
     ),

--- a/lib/CorleoneOED/test/qa/qa.jl
+++ b/lib/CorleoneOED/test/qa/qa.jl
@@ -1,8 +1,28 @@
+using SciMLTesting
 using CorleoneOED
-using Aqua
+using Test
 
-@testset "Aqua" begin
-    Aqua.test_all(
-        CorleoneOED
-    )
-end
+run_qa(
+    CorleoneOED;
+    explicit_imports = true,
+    # CorleoneOED pulls Corleone and its other deps in with bare `using`, so it
+    # leans on a large set of implicit imports. Converting every one to an
+    # explicit import is a sizable refactor tracked in SciML/Corleone.jl#103.
+    ei_broken = (:no_implicit_imports,),
+    ei_kwargs = (;
+        # Deliberate uses of internal names that are not (yet) declared public in
+        # their owning modules: Base/stdlib internals, SciML internals, and
+        # Corleone's own as-yet-unexported helpers reached through `Corleone.*`.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :AbstractDEAlgorithm, :AbstractDEProblem, :Code, :Fix1, :Fix2,
+                :Tunable, :build_index_grid, :canonicalize, :front,
+                :get_block_structure, :get_bounds, :get_colorizers,
+                :get_number_of_shooting_constraints, :get_timegrid, :getdefaultval,
+                :initialparameters, :initialstates, :jacobian,
+                :retrieve_symbol_cache, :setdefaultval, :shooting_constraints,
+                :shooting_constraints!, :variable, :variables,
+            ),
+        ),
+    ),
+)

--- a/lib/OptimalControlBenchmarks/test/qa/Project.toml
+++ b/lib/OptimalControlBenchmarks/test/qa/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Corleone = "2751e0db-33e9-4374-b36d-b7219e1e6b40"
 OptimalControlBenchmarks = "d147904a-1eb9-11f1-01e7-bdf88e0f9445"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -12,5 +13,6 @@ OptimalControlBenchmarks = {path = "../.."}
 Aqua = "0.8"
 Corleone = "0.0.5"
 OptimalControlBenchmarks = "0.0.3"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/lib/OptimalControlBenchmarks/test/qa/qa.jl
+++ b/lib/OptimalControlBenchmarks/test/qa/qa.jl
@@ -1,8 +1,20 @@
+using SciMLTesting
 using OptimalControlBenchmarks
-using Aqua
+using Test
 
-@testset "Aqua" begin
-    Aqua.test_all(
-        OptimalControlBenchmarks
-    )
-end
+run_qa(
+    OptimalControlBenchmarks;
+    explicit_imports = true,
+    ei_kwargs = (;
+        # `problem_registry.jl` registers problems through a dynamic `include`,
+        # which ExplicitImports cannot follow, so the module is unanalyzable for
+        # the implicit/stale checks.
+        no_implicit_imports = (; allow_unanalyzable = (OptimalControlBenchmarks,)),
+        no_stale_explicit_imports = (; allow_unanalyzable = (OptimalControlBenchmarks,)),
+        # `inputs` is re-exported by ModelingToolkit from ModelingToolkitBase.
+        all_explicit_imports_via_owners = (; ignore = (:inputs,)),
+        all_explicit_imports_are_public = (; ignore = (:inputs,)),
+        # Deliberate uses of internal names not (yet) declared public upstream.
+        all_qualified_accesses_are_public = (; ignore = (:default_rng, :initialstates)),
+    ),
+)

--- a/lib/OptimalControlBenchmarks/test/qa/qa.jl
+++ b/lib/OptimalControlBenchmarks/test/qa/qa.jl
@@ -13,8 +13,5 @@ run_qa(
         no_stale_explicit_imports = (; allow_unanalyzable = (OptimalControlBenchmarks,)),
         # `inputs` is re-exported by ModelingToolkit from ModelingToolkitBase.
         all_explicit_imports_via_owners = (; ignore = (:inputs,)),
-        all_explicit_imports_are_public = (; ignore = (:inputs,)),
-        # Deliberate uses of internal names not (yet) declared public upstream.
-        all_qualified_accesses_are_public = (; ignore = (:default_rng, :initialstates)),
     ),
 )

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -12,6 +12,6 @@ Corleone = {path = "../.."}
 Aqua = "0.8"
 Corleone = "0.0.5"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,8 +1,28 @@
+using SciMLTesting
 using Corleone
-using Aqua
+using Test
 
-@testset "Aqua" begin
-    Aqua.test_all(
-        Corleone
-    )
-end
+run_qa(
+    Corleone;
+    explicit_imports = true,
+    # Corleone pulls all of its deps in with bare `using`, so the package leans
+    # on a large set of implicit imports. Converting every one to an explicit
+    # import is a sizable refactor tracked in SciML/Corleone.jl#103.
+    ei_broken = (:no_implicit_imports,),
+    ei_kwargs = (;
+        # `ADTypes` is reached through `SciMLBase.ADTypes.AbstractADType`; ADTypes
+        # is not a direct Corleone dependency, so the access goes via SciMLBase.
+        all_qualified_accesses_via_owners = (; ignore = (:ADTypes,)),
+        # Deliberate uses of well-known Base/stdlib/SciML internal names that are
+        # not (yet) declared public in their owning modules.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :ADTypes, :AbstractDEAlgorithm, :AbstractDEProblem,
+                :AbstractVecOrTuple, :EnsembleAlgorithm, :Fix1, :Fix2, :OneTo,
+                :Splat, :Tunable, :canonicalize, :default_rng, :front,
+                :get_colorizers, :initialparameters, :initialstates,
+                :parameterlength, :setup, :tail,
+            ),
+        ),
+    ),
+)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -13,15 +13,16 @@ run_qa(
         # `ADTypes` is reached through `SciMLBase.ADTypes.AbstractADType`; ADTypes
         # is not a direct Corleone dependency, so the access goes via SciMLBase.
         all_qualified_accesses_via_owners = (; ignore = (:ADTypes,)),
-        # Deliberate uses of well-known Base/stdlib/SciML internal names that are
-        # not (yet) declared public in their owning modules.
+        # Names still not declared public in their owning modules: Base internals
+        # (`AbstractVecOrTuple`, `Splat`), SciMLBase internals (`ADTypes`,
+        # `AbstractDEAlgorithm`, `AbstractDEProblem`, `EnsembleAlgorithm`,
+        # `get_colorizers`), and SciMLStructures internals (`Tunable`,
+        # `canonicalize`).
         all_qualified_accesses_are_public = (;
             ignore = (
                 :ADTypes, :AbstractDEAlgorithm, :AbstractDEProblem,
-                :AbstractVecOrTuple, :EnsembleAlgorithm, :Fix1, :Fix2, :OneTo,
-                :Splat, :Tunable, :canonicalize, :default_rng, :front,
-                :get_colorizers, :initialparameters, :initialstates,
-                :parameterlength, :setup, :tail,
+                :AbstractVecOrTuple, :EnsembleAlgorithm, :Splat, :Tunable,
+                :canonicalize, :get_colorizers,
             ),
         ),
     ),


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Converts every QA environment in the monorepo (root + both `lib/` sublibraries) to the SciMLTesting v1.6 `run_qa` form with ExplicitImports enabled.

Per QA env the old hand-rolled `@testset "Aqua" Aqua.test_all(Mod)` becomes `run_qa(Mod; explicit_imports = true, ...)`, which runs Aqua (unchanged) plus the six ExplicitImports checks behind one dispatcher. SciMLTesting compat is bumped to `1.6` in each `test/qa/Project.toml`; ExplicitImports is pulled transitively (not added to `[deps]`). The `[sources]`/develop wiring for the sublibs is left exactly as is. No JET is run in any of these envs (none ran it before; QA lanes only run on `lts`/`1`, so the prerelease-JET crash class does not apply).

## ExplicitImports findings per env

**root `Corleone`** — verified locally on released SciMLTesting 1.6.0, Julia 1.10: `Quality Assurance | 16 Pass, 1 Broken, 0 Fail`.
- `no_implicit_imports`: package uses bare `using` for all deps -> large implicit-import surface; marked `ei_broken` and tracked in the issue below (auto-flags an Unexpected Pass once fixed).
- `all_qualified_accesses_via_owners`: ignore `:ADTypes` (reached via `SciMLBase.ADTypes.AbstractADType`; ADTypes is not a direct dep).
- `all_qualified_accesses_are_public`: ignore deliberate Base/stdlib/SciML internal names (`Fix1`, `Fix2`, `tail`, `front`, `OneTo`, `Splat`, `canonicalize`, `Tunable`, `setup`, `initialparameters`, ...).
- remaining checks pass.

**`lib/CorleoneOED`** — verified locally: EI part `5 Pass, 1 Broken, 0 Fail`.
- `no_implicit_imports`: same bare-`using` pattern -> `ei_broken` (tracked).
- `all_qualified_accesses_are_public`: ignore Base/SciML internals plus CorleoneOED's own as-yet-unexported helpers reached through `Corleone.*` (`get_bounds`, `get_block_structure`, `shooting_constraints`, ...).
- remaining checks pass.

**`lib/OptimalControlBenchmarks`** — verified locally: EI part `6 Pass, 0 Fail, 0 Broken` (no broken markers needed).
- `no_implicit_imports` / `no_stale_explicit_imports`: the module is *unanalyzable* (dynamic `include` in `problem_registry.jl`), so `allow_unanalyzable = (OptimalControlBenchmarks,)`.
- `all_explicit_imports_via_owners` / `all_explicit_imports_are_public`: ignore `:inputs` (re-exported by ModelingToolkit from ModelingToolkitBase).
- `all_qualified_accesses_are_public`: ignore `:default_rng` (Random), `:initialstates` (LuxCore).

## Pre-existing Aqua failures (NOT introduced here)

The `lib/CorleoneOED [QA]` and `lib/OptimalControlBenchmarks [QA]` lanes are **already red on master** (SublibraryCI run #101) from genuine Aqua failures: CorleoneOED has method ambiguities, an unbound type param, undefined export `CorleoneOED.Variable`, stale deps, a missing `Pkg` extras-compat entry, and type piracy; OptimalControlBenchmarks has stale deps and missing deps/extras compat entries. This PR runs the *same* `Aqua.test_all` as before with **no new disables** — it does not mask those failures with `aqua_broken`, and does not make them worse. They need a separate real fix and are out of scope for this QA-form conversion.

Sublibs converted: 2 (CorleoneOED, OptimalControlBenchmarks), plus the root QA env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Tracking issue for the `no_implicit_imports` broken markers: #103.