### PR TITLE
Bump sublibrary/test Corleone compat 0.0.4 -> 0.0.5 to match released parent

### DIFF
--- a/lib/CorleoneOED/Project.toml
+++ b/lib/CorleoneOED/Project.toml
@@ -27,7 +27,7 @@ CorleoneOEDOptimizationExtension = ["Optimization", "ComponentArrays"]
 CorleoneOEDZygoteExtension = "Zygote"
 
 [compat]
-Corleone = "0.0.4"
+Corleone = "0.0.5"
 ComponentArrays = "0.15"
 DocStringExtensions = "0.9"
 ForwardDiff = "1.3"

--- a/lib/CorleoneOED/test/qa/Project.toml
+++ b/lib/CorleoneOED/test/qa/Project.toml
@@ -10,7 +10,7 @@ CorleoneOED = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-Corleone = "0.0.4"
-CorleoneOED = "0.0.4"
+Corleone = "0.0.5"
+CorleoneOED = "0.0.5"
 Test = "1"
 julia = "1.10"

--- a/lib/OptimalControlBenchmarks/Project.toml
+++ b/lib/OptimalControlBenchmarks/Project.toml
@@ -33,7 +33,7 @@ UnoSolver = "1baa60ac-02f7-4b39-a7a8-2f4f58486b05"
 
 [compat]
 ComponentArrays = "0.15"
-Corleone = "0.0.4"
+Corleone = "0.0.5"
 DocStringExtensions = "0.9"
 ForwardDiff = "1.3"
 Ipopt = "1"

--- a/lib/OptimalControlBenchmarks/test/qa/Project.toml
+++ b/lib/OptimalControlBenchmarks/test/qa/Project.toml
@@ -10,7 +10,7 @@ OptimalControlBenchmarks = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-Corleone = "0.0.4"
+Corleone = "0.0.5"
 OptimalControlBenchmarks = "0.0.3"
 Test = "1"
 julia = "1.10"

--- a/test/examples/Project.toml
+++ b/test/examples/Project.toml
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ComponentArrays = "0.15"
-Corleone = "0.0.4"
+Corleone = "0.0.5"
 ForwardDiff = "1.2"
 Ipopt = "1.10"
 LuxCore = "1.4"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -10,7 +10,7 @@ Corleone = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-Corleone = "0.0.4"
+Corleone = "0.0.5"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1"
 Test = "1"


### PR DESCRIPTION
## Problem

The **Downgrade Sublibraries** lane (and the regular **Sublibrary CI** / **QA** lanes) are red on `main`:

```
ERROR: LoadError: empty intersection between Corleone@0.0.5 and project compatibility 0.0.4
```

PRs #104/#105 released parent **Corleone v0.0.5** but did not update the sublibraries' / test sub-projects' `Corleone` `[compat]`, which still pinned `"0.0.4"`. For pre-1.0 versions the caret range `"0.0.4"` means `[0.0.4, 0.0.5)`, so the path-sourced parent at 0.0.5 (`[sources] Corleone = {path = "../.."}`) has an **empty intersection** with that compat. The conflict surfaces during the `Pkg.test` test-sandbox resolve.

The root **Downgrade** (main) lane is green because the root package does not depend on itself.

This is the same recurring pattern that PR #101 fixed for the `0.0.3 -> 0.0.4` parent release.

## Fix

Bump `Corleone = "0.0.4"` -> `"0.0.5"` in the 5 path-sourcing Project.tomls, plus the now-stale `CorleoneOED = "0.0.4"` -> `"0.0.5"` self-compat in `lib/CorleoneOED/test/qa/Project.toml` (CorleoneOED was released as v0.0.5 in #105 and is path-sourced there). `OptimalControlBenchmarks` stays at `0.0.3` (matches its current version).

Files:
- `lib/CorleoneOED/Project.toml`
- `lib/CorleoneOED/test/qa/Project.toml` (Corleone + CorleoneOED)
- `lib/OptimalControlBenchmarks/Project.toml`
- `lib/OptimalControlBenchmarks/test/qa/Project.toml`
- `test/examples/Project.toml`
- `test/qa/Project.toml`

## Verification (Julia 1.10.11, lts)

`Pkg.develop` of the path-sourced parent into `lib/OptimalControlBenchmarks`:
- **unmodified tree:** `empty intersection between Corleone@0.0.5 and project compatibility 0.0.4` (reproduces the CI error byte-for-byte)
- **with this change:** succeeds — `Corleone v0.0.5 ../..` accepted

Also confirmed via `semver_spec`: `0.0.5 ∈ "0.0.4"` is `false` (the conflict), `0.0.5 ∈ "0.0.5"` is `true` (the fix).

Note: a clean-depot full `Pkg.test` resolve still hits the separate, pre-existing fleet-wide LogExpFunctions/SparseConnectivityTracer upstream resolution wall; that is independent of this compat bump and is not what these lanes were failing on (they died earlier, at the Corleone compat check).

---

**Ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)