### PR TITLE
Resolve in-repo docs dependencies

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -21,3 +21,7 @@ OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+
+[sources]
+CorleoneOED = {path = "../lib/CorleoneOED"}
+OptimalControlBenchmarks = {path = "../lib/OptimalControlBenchmarks"}


### PR DESCRIPTION
This is a focused follow-up to #109. It adds docs `[sources]` entries for the in-repo CorleoneOED and OptimalControlBenchmarks dependencies so the docs environment can resolve the packages during the CI install step.

Please ignore this draft PR until reviewed by @ChrisRackauckas.

Local verification:
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` passed before #109 was squash-merged.\n- `timeout 3600 env GROUP=CorleoneOED /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` passed before #109 was squash-merged.\n- `timeout 3600 env GROUP=OptimalControlBenchmarks /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` passed before #109 was squash-merged.\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 -e 'using Runic; exit(Runic.main(ARGS))' -- --check .` passed after this rebase.\n- `git diff --check` passed after this rebase.\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'` passed after this rebase.\n- Full docs build passed on the identical tree before rebasing onto the squash merge (`1921e6b` and current `4baa5c1` have tree `9fb1e6b2158a88ef51a13ea49d8f0fb9cee6daaa`). Two post-rebase reruns were externally terminated with exit code 143 during example generation and produced no Julia/Documenter error.