### PR TITLE
Release prep: batched version bumps for 1 package (+ completing a stuck root registration)

### DIFF
--- a/lib/CorleoneOED/Project.toml
+++ b/lib/CorleoneOED/Project.toml
@@ -1,7 +1,7 @@
 name = "CorleoneOED"
 uuid = "6590a4b1-d036-41fe-a5b4-03a980244101"
 authors = ["Christoph Plate", "Carl Julius Martensen", "Sebastian Sager"]
-version = "0.0.5"
+version = "0.0.6"
 
 [deps]
 Corleone = "2751e0db-33e9-4374-b36d-b7219e1e6b40"

--- a/lib/CorleoneOED/test/qa/Project.toml
+++ b/lib/CorleoneOED/test/qa/Project.toml
@@ -11,7 +11,7 @@ Corleone = {path = "../../../.."}
 [compat]
 Aqua = "0.8"
 Corleone = "0.0.5"
-CorleoneOED = "0.0.5"
+CorleoneOED = "0.0.6"
 SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
## Summary

This is a small release-prep PR: only **CorleoneOED** gets a `Project.toml` version bump here. Root **Corleone**'s version field is already at `0.0.5` from a prior merged PR (#104) and does not need another bump -- see "Root Corleone" below for why it still needs action, just not a Project.toml edit.

### CorleoneOED: 0.0.5 -> 0.0.6 (patch) -- own changes

Diff scope: `lib/CorleoneOED/` from the registered v0.0.5 commit (013ecb4, General PR [#159430](https://github.com/JuliaRegistries/General/pull/159430), tree-sha `40906d7d`) to current HEAD.

Classified **SAFE** for a routine release:
- Aqua QA fixes: drop unbound `DISCRETE`/`SPLIT` type params from `update_fim` methods (unused, non-binding -- behavior-preserving); add disambiguating `get_sampling_sums(!)` overloads for `OEDLayer{<:Any,false,<:Any,<:MultipleShootingLayer}` (fixes a real method-ambiguity hazard).
- Remove `shooting_constraints(!)(::AbstractVector{<:Trajectory})` type piracy from CorleoneOED -- those methods now live in Corleone itself (see below), which owns both the function and `Trajectory`.
- Stale-dep cleanup: `StableRNGs` moved from `[deps]` to `[extras]`/test target (only used in `test/core`).
- Docstring / public-API-coverage additions (oed.jl, multiexperiments.jl, reexported Symbolics bindings) -- no behavior change.
- Test harness migrated to the `SciMLTesting` v2.1 `run_tests` dispatcher.
- Downstream compat floor raises: `SciMLBase` "2, 3" -> "2.141.0, 3", `SymbolicIndexingInterface` "0.3" -> "0.3.43", `Reexport` "1.2" -> "1.2.2", `DocStringExtensions` "0.9" -> "0.9.3" (all matching floors the parent Corleone already requires; fixes real downgrade-CI dead-ends).

No new exported/public API of its own, so patch (not minor).

Also bumps CorleoneOED's **self-referential** compat pin in its own QA env, `lib/CorleoneOED/test/qa/Project.toml` (`CorleoneOED = "0.0.5"` -> `"0.0.6"`), which path-sources CorleoneOED itself for the Aqua lane -- otherwise the downgrade CI lane hits the same "empty intersection" class of failure that PRs #101/#106 fixed for the parent Corleone self-pin.

**Compat floor cascade check (Step 3):** CorleoneOED's compat floor on `Corleone` stays at `"0.0.5"` -- unchanged, because Corleone's version field is not changing in this PR (see next section), and `0.0.5` already contains the `shooting_constraints` methods CorleoneOED's current source now relies on (moved there in #108, before 0.0.5's registration commit). No update needed.

### Root Corleone: registration completion, no version bump

Root's own file-diff scope (all paths excluding `lib/`) from the last **registered** version (v0.0.4, commit 6335ba5, General PR [#158790](https://github.com/JuliaRegistries/General/pull/158790)) to current HEAD is also **SAFE**: QA/CI/docs changes, `SciMLTesting` compat floor bump, and the Aqua-driven fixes in #108 (dropping unbound type params; adding `shooting_constraints(!)(::AbstractVector{<:Trajectory})`, an **unexported/internal** method, to fix CorleoneOED's type piracy). No new exported public API.

Root's `Project.toml` `version` field was already bumped to `0.0.5` by a prior merged PR (#104), but **that version was never actually registered**: General PR [#159336](https://github.com/JuliaRegistries/General/pull/159336) ("New version: Corleone v0.0.5") is still open, referencing an older commit (7180b21, two trivial CI/docs-only commits behind current HEAD). It is stuck because RegistryCI's AutoMerge auto-labels *any* 0.0.x version change as `BREAKING` and blocks pending release notes -- the exact same mechanical gate that v0.0.4 and CorleoneOED v0.0.5 hit and cleared by simply re-invoking JuliaRegistrator with release notes attached (see those PRs' commit-comment history).

Editing root's `Project.toml` version again here would either collide with that open PR (same version number, different tree-sha) or skip a version number outright -- both are AutoMerge guideline violations. The correct, already-precedented fix is to **re-invoke `@JuliaRegistrator register()` with release notes on the new default-branch HEAD after this PR merges**, which updates PR #159336 in place (JuliaRegistrator explicitly supports this: "You do not need to change the version number... simply re-trigger Registrator"). No Project.toml edit is required or made here.

### Out of scope

`lib/OptimalControlBenchmarks` depends on `Corleone` (compat `"0.0.5"`, already consistent) but has never been registered in General (no matching PRs found), so it is not part of this release and is left untouched.

## Test plan
- [ ] CI matrix passes on this PR (root + both sublibraries, QA/Aqua, downgrade lanes)
- [ ] `lib/CorleoneOED/test/qa` Aqua lane passes with the bumped self-compat pin
- [ ] After merge: re-trigger Corleone v0.0.5 registration (with release notes) on the new HEAD to unstick General PR #159336
- [ ] After that merges: trigger CorleoneOED v0.0.6 registration via `@JuliaRegistrator register subdir=lib/CorleoneOED`