### PR TITLE
Document rendered public API coverage

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,21 +2,42 @@
 
 ## Corleone
 
-```@autodocs
-Modules = [Corleone]
-Order = [:type, :function]
+```@docs
+Corleone.Trajectory
+Corleone.ControlParameter
+Corleone.SingleShootingLayer
+Corleone.MultipleShootingLayer
+Corleone.default_initialization
+Corleone.random_initialization
+Corleone.forward_initialization
+Corleone.linear_initialization
+Corleone.custom_initialization
+Corleone.constant_initialization
+Corleone.hybrid_initialization
+Corleone.CorleoneDynamicOptProblem
 ```
 
 ## CorleoneOED
 
-```@autodocs
-Modules = [CorleoneOED]
-Order = [:type, :function]
+```@docs
+CorleoneOED.OEDLayer
+CorleoneOED.fisher_information
+CorleoneOED.observed_equations
+CorleoneOED.sensitivities
+CorleoneOED.local_information_gain
+CorleoneOED.global_information_gain
+CorleoneOED.MultiExperimentLayer
+CorleoneOED.ACriterion
+CorleoneOED.DCriterion
+CorleoneOED.ECriterion
+CorleoneOED.FisherACriterion
+CorleoneOED.FisherECriterion
+CorleoneOED.FisherDCriterion
 ```
 
 ## OptimalControlBenchmarks
 
-```@autodocs
-Modules = [OptimalControlBenchmarks]
-Order = [:type, :function]
+```@docs
+OptimalControlBenchmarks.load_benchmarks
+OptimalControlBenchmarks.run_all
 ```

--- a/lib/CorleoneOED/src/CorleoneOED.jl
+++ b/lib/CorleoneOED/src/CorleoneOED.jl
@@ -12,69 +12,6 @@ using SciMLBase
 using DocStringExtensions
 using LinearAlgebra
 
-"""
-    @symbolic_wrap(ex)
-
-Reexported from Symbolics; wrap an expression as a symbolic value.
-"""
-var"@symbolic_wrap"
-
-"""
-    @wrapped(ex)
-
-Reexported from Symbolics; create a wrapped symbolic expression.
-"""
-var"@wrapped"
-
-"""
-    RuleSet
-
-Reexported from Symbolics; a collection of symbolic rewrite rules.
-"""
-RuleSet
-
-"""
-    get_canonical_expr(x)
-
-Reexported from Symbolics; return the canonical symbolic expression for `x`.
-"""
-get_canonical_expr
-
-"""
-    infimum(x)
-
-Reexported from Symbolics; return the lower endpoint or symbolic infimum of `x`.
-"""
-infimum
-
-"""
-    is_derivative(x)
-
-Reexported from Symbolics; test whether `x` represents a symbolic derivative.
-"""
-is_derivative
-
-"""
-    istree(x)
-
-Reexported from Symbolics; test whether `x` has tree-structured symbolic arguments.
-"""
-istree
-
-"""
-    solve_for(args...)
-
-Reexported from Symbolics; solve a symbolic equation or system for selected variables.
-"""
-solve_for
-
-"""
-    supremum(x)
-
-Reexported from Symbolics; return the upper endpoint or symbolic supremum of `x`.
-"""
-supremum
-
 # TODO Clean and more tests (also for LV)
 include("augmentation.jl")
 

--- a/lib/CorleoneOED/test/qa/qa.jl
+++ b/lib/CorleoneOED/test/qa/qa.jl
@@ -2,6 +2,14 @@ using SciMLTesting
 using CorleoneOED
 using Test
 
+const DEPENDENCY_REEXPORTS = let
+    reexports = Set{Symbol}()
+    union!(reexports, public_api_names(CorleoneOED.Corleone))
+    union!(reexports, public_api_names(CorleoneOED.Symbolics))
+    push!(reexports, :Corleone, :Symbolics)
+    Tuple(sort!(collect(reexports)))
+end
+
 run_qa(
     CorleoneOED;
     explicit_imports = true,
@@ -26,5 +34,11 @@ run_qa(
                 :shooting_constraints, :shooting_constraints!, :variables,
             ),
         ),
+    ),
+    api_docs_kwargs = (;
+        rendered = true,
+        docs_src = normpath(@__DIR__, "..", "..", "..", "..", "docs", "src"),
+        ignore = DEPENDENCY_REEXPORTS,
+        rendered_ignore = DEPENDENCY_REEXPORTS,
     ),
 )

--- a/lib/OptimalControlBenchmarks/test/qa/qa.jl
+++ b/lib/OptimalControlBenchmarks/test/qa/qa.jl
@@ -14,4 +14,8 @@ run_qa(
         # `inputs` is re-exported by ModelingToolkit from ModelingToolkitBase.
         all_explicit_imports_via_owners = (; ignore = (:inputs,)),
     ),
+    api_docs_kwargs = (;
+        rendered = true,
+        docs_src = normpath(@__DIR__, "..", "..", "..", "..", "docs", "src"),
+    ),
 )

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -26,4 +26,5 @@ run_qa(
             ),
         ),
     ),
+    api_docs_kwargs = (; rendered = true),
 )


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Replace broad API autodocs with explicit rendered docs entries for package-owned public names.
- Remove local CorleoneOED doc stubs for Symbolics-owned reexports.
- Enable SciMLTesting rendered public API docs QA for Corleone, CorleoneOED, and OptimalControlBenchmarks; CorleoneOED ignores dependency-owned reexports.

## Validation
- `git diff --check` passed.
- Runic 1.7.0 passed on touched Julia files.
- Root QA passed on Julia 1.10: 16 pass, 1 existing broken.
- CorleoneOED QA passed on Julia 1.10: 16 pass, 1 existing broken.
- OptimalControlBenchmarks QA reached and passed Public API documentation (2/2), but overall QA failed in Aqua persistent_tasks during dependency precompilation.
- Docs build was attempted on Julia 1.10 and failed in the existing linear quadratic regulator tutorial solve.

## Blockers
- OptimalControlBenchmarks QA blocker: Aqua persistent_tasks failed while precompiling the MTK/NonlinearSolve stack with `MethodError: no method matching defaultalg_symbol(::Type{LinearSolve.QRFactorization{LinearAlgebra.NoPivot}})` / world-age wording.
- Docs build blocker: `examples/linear_quadratic/main.jl` failed during Literate execution at `solve(optprob, OptimizationLBFGSB.LBFGSB())` with `ArgumentError: type does not have a definite number of fields`.
