### PR TITLE
Bump CorleoneOED to v0.0.7

### DIFF
--- a/lib/CorleoneOED/Project.toml
+++ b/lib/CorleoneOED/Project.toml
@@ -1,7 +1,7 @@
 name = "CorleoneOED"
 uuid = "6590a4b1-d036-41fe-a5b4-03a980244101"
 authors = ["Christoph Plate", "Carl Julius Martensen", "Sebastian Sager"]
-version = "0.0.6"
+version = "0.0.7"
 
 [deps]
 Corleone = "2751e0db-33e9-4374-b36d-b7219e1e6b40"


### PR DESCRIPTION
Bumps `CorleoneOED` **v0.0.6 → v0.0.7** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Migrate Corleone QA to SciMLTesting 2.4 (#116) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)