### PR TITLE
Make QA scan the package extensions

### DIFF
--- a/ext/CorleoneModelingToolkitExtension.jl
+++ b/ext/CorleoneModelingToolkitExtension.jl
@@ -8,7 +8,7 @@ using ModelingToolkit
 using Corleone.LuxCore
 using Corleone.Random
 using Corleone.DocStringExtensions
-using Corleone.SciMLBase
+using SciMLBase
 
 using ModelingToolkit.Symbolics
 using ModelingToolkit.SymbolicUtils

--- a/ext/MTKExtension/optimal_control.jl
+++ b/ext/MTKExtension/optimal_control.jl
@@ -2,10 +2,10 @@ function Corleone.CorleoneDynamicOptProblem(
         sys::ModelingToolkit.System,
         inits::AbstractVector,
         controls::Pair...;
-        algorithm::Corleone.SciMLBase.AbstractDEAlgorithm,
+        algorithm::SciMLBase.AbstractDEAlgorithm,
         shooting::Union{<:AbstractVector{<:Real}, Nothing} = nothing,
         tspan::Union{Tuple{Real, Real}, Nothing} = nothing,
-        sensealg = ModelingToolkit.SciMLBase.NoAD(),
+        sensealg = SciMLBase.NoAD(),
         kwargs...
     )
     iv = ModelingToolkit.get_iv(sys)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,13 +1,19 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 Corleone = "2751e0db-33e9-4374-b36d-b7219e1e6b40"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
+ComponentArrays = "0.15"
 Corleone = "0.0.5"
+Makie = "0.24"
+ModelingToolkit = "11"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
 Test = "1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,25 @@ using SciMLTesting
 using Corleone
 using Test
 
+# ExplicitImports only sees an extension once its trigger package is loaded, so the
+# three extension triggers are loaded here to bring `ext/` into the checked module set.
+# The `Optimization` weakdep triggers no extension of this package (it is the trigger
+# for CorleoneOED's extension), so it is deliberately not loaded here.
+using ComponentArrays, Makie, ModelingToolkit
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    exts = (
+        :CorleoneComponentArraysExtension,
+        :CorleoneMakieExtension,
+        :CorleoneModelingToolkitExtension,
+    )
+    for ext in exts
+        @test Base.get_extension(Corleone, ext) !== nothing
+    end
+end
+
 run_qa(
     Corleone;
     # Corleone pulls all of its deps in with bare `using`, so the package leans
@@ -22,6 +41,18 @@ run_qa(
                 :ADTypes, :AbstractDEAlgorithm, :AbstractDEProblem,
                 :AbstractVecOrTuple, :EnsembleAlgorithm, :Splat, :Tunable,
                 :canonicalize, :get_colorizers,
+                # Corleone's own internals. The extensions exist to add methods to
+                # these, which is only expressible as a qualified access into the
+                # parent package; they are internal hooks, not user API.
+                :AbstractCorleoneFunctionWrapper, :get_number_of_shooting_constraints,
+                :retrieve_symbol_cache, :shooting_constraints!, :to_vec,
+                :wrap_functions,
+                # Symbolics/SymbolicUtils term-rewriting internals used to normalize
+                # MTK constraints and read symbolic defaults; no public spelling.
+                :Code, :canonical_form, :getdefaultval,
+                # Makie's recipe hooks, which every plot recipe must implement even
+                # though they are not declared `public`.
+                :plotsym, :plottype,
             ),
         ),
     ),


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## What this fixes

`SciMLTesting.run_qa` runs ExplicitImports' checks over the package module *and its
extensions* — but ExplicitImports skips any extension whose `Base.get_extension` returns
`nothing`, and an extension module only exists once its trigger package is loaded. The QA
environment loaded no weakdeps, so **none of the three `ext/` modules was ever checked**.

Verified on the unmodified `main` QA environment:

```
CorleoneMakieExtension => nothing
CorleoneComponentArraysExtension => nothing
CorleoneModelingToolkitExtension => nothing
SCANNED: Corleone
```

After this PR, in the same environment:

```
CorleoneMakieExtension => CorleoneMakieExtension
CorleoneComponentArraysExtension => CorleoneComponentArraysExtension
CorleoneModelingToolkitExtension => CorleoneModelingToolkitExtension
SCANNED: CorleoneModelingToolkitExtension
SCANNED: CorleoneMakieExtension
SCANNED: Corleone
SCANNED: CorleoneComponentArraysExtension
```

## Coverage

All three extensions are scanned; nothing is left unscanned. Makie loads headless without
trouble, so the Makie extension is covered too.

The fourth weakdep, `Optimization`, is **not** added: it triggers no extension of this
package. The root `[weakdeps]`/`[compat]` list it, but `[extensions]` has no entry for it —
`Optimization` is the trigger for `lib/CorleoneOED`'s `CorleoneOEDOptimizationExtension`.
Adding it to the QA environment would load a large dependency and scan nothing. Worth
noting separately: the root `Optimization` weakdep looks stale and could probably be
dropped, but that is out of scope here.

Also out of scope: `lib/CorleoneOED` and `lib/OptimalControlBenchmarks` have their own
`test/qa` environments with the same gap. Those are follow-ups.

A `@testset "Extensions loaded"` guard is included, because ExplicitImports silently skips
an extension that fails to load: without the guard, a future change that broke an
extension's precompilation would make QA go green while coverage dropped back to zero.

## Fixed at the source rather than ignored

`CorleoneModelingToolkitExtension` reached SciMLBase through re-exporters:

* `algorithm::Corleone.SciMLBase.AbstractDEAlgorithm` (via the parent package)
* `sensealg = ModelingToolkit.SciMLBase.NoAD()` (via ModelingToolkit)

SciMLBase is a direct Corleone dependency, so the extension can and now does use it
directly: the module header becomes `using SciMLBase` and both accesses become
`SciMLBase.…`. This clears both `all_qualified_accesses_via_owners` findings.

## Ignore entries added

All added to `all_qualified_accesses_are_public`:

* `:AbstractCorleoneFunctionWrapper, :get_number_of_shooting_constraints,
  :retrieve_symbol_cache, :shooting_constraints!, :to_vec, :wrap_functions` — Corleone's
  own internals. Each extension exists to add methods to these, which is only expressible
  as a qualified access into the parent package. They are internal hooks, not user API.
* `:Code, :canonical_form, :getdefaultval` — Symbolics/SymbolicUtils term-rewriting
  internals used to normalize MTK constraints (`Symbolics.canonical_form`) and read
  symbolic defaults (`Symbolics.getdefaultval`), plus the `SymbolicUtils.Code` submodule.
  None is declared public at its owner and there is no public spelling.
* `:plotsym, :plottype` — Makie's recipe hooks, which every plot recipe must implement even
  though Makie does not declare them `public`.

No check was disabled and no new `@test_broken` was added. The pre-existing
`ei_broken = (:no_implicit_imports,)` (tracked in #103) stays broken — the extensions add
more entries to that list, all of the same `using Foo` / use-`Foo.bar` kind covered by that
issue.

## Local result

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on Julia 1.12.6:

```
Test Summary:          | Pass  Broken  Total     Time
Code quality (Aqua.jl) |   22       1     23  1m44.5s
     Testing Corleone tests passed
```

(Before the SciMLBase source fix and the new ignores, the same run reported
`20 passed, 0 failed, 2 errored, 1 broken`.)

Also verified on Julia 1.10.11 (the LTS leg of the QA group) that the environment resolves
and all three extensions load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb5kCpT5SRzTrhppKSh1n7
