### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Corleone"
 uuid = "2751e0db-33e9-4374-b36d-b7219e1e6b40"
 authors = ["Carl Julius Martensen <carl.martensen@ovgu.de>", "Christoph Plate <christoph.plate@ovgu.de>", "and contributors"]
-version = "0.0.6"
+version = "0.0.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/lib/CorleoneOED/Project.toml
+++ b/lib/CorleoneOED/Project.toml
@@ -1,7 +1,7 @@
 name = "CorleoneOED"
 uuid = "6590a4b1-d036-41fe-a5b4-03a980244101"
 authors = ["Christoph Plate", "Carl Julius Martensen", "Sebastian Sager"]
-version = "0.0.7"
+version = "0.0.8"
 
 [deps]
 Corleone = "2751e0db-33e9-4374-b36d-b7219e1e6b40"


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `main` can be registered in the General registry.

- Corleone: 0.0.6 -> 0.0.7
- CorleoneOED: 0.0.7 -> 0.0.8

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
