### PR TITLE
compat: align QA environment with package version

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,7 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 ComponentArrays = "0.15"
-Corleone = "0.0.6"
+Corleone = "0.0.7"
 Makie = "0.24"
 ModelingToolkit = "11"
 SafeTestsets = "0.1, 1"


### PR DESCRIPTION
Updates only `test/qa/Project.toml` so its local Corleone compat bound matches the package version declared on `main` (`0.0.7`). This lets the QA environment resolve the checked-out package instead of rejecting it as incompatible.

Please ignore until reviewed by @ChrisRackauckas.

## Verification

- `GROUP=QA julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`\n  - `Code quality (Aqua.jl) | Pass 22 Broken 1 Total 23`\n  - `Testing Corleone tests passed`\n- `julia --startup-file=no --project=. -e 'using TOML; TOML.parsefile("test/qa/Project.toml"); println("TOML parse passed")'`\n  - `TOML parse passed`\n- `typos --format brief test/qa/Project.toml`\n- `git diff --check`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791