### PR TITLE
Format for Runic v1.10

### DIFF
--- a/lib/CorleoneOED/src/multiexperiments.jl
+++ b/lib/CorleoneOED/src/multiexperiments.jl
@@ -37,8 +37,8 @@ function Base.show(io::IO, oed::MultiExperimentLayer{DISCRETE, FIXED, SPLIT}) wh
         )
         [
             print(
-                    io, "Experiment $i considers parameters: $param." * (i == length(params.original) ? "" : "\n")
-                ) for (i, param) in enumerate(params.original)
+                io, "Experiment $i considers parameters: $param." * (i == length(params.original) ? "" : "\n")
+            ) for (i, param) in enumerate(params.original)
         ]
     end
 end

--- a/src/single_shooting.jl
+++ b/src/single_shooting.jl
@@ -251,10 +251,10 @@ function retrieve_symbol_cache(::Nothing, u0, p, control_indices; control_names 
     p_id = 0
     parameter_symbols = [
         if i ∈ control_indices
-                u_id += 1
-                control_names[u_id]
+            u_id += 1
+            control_names[u_id]
         else
-                Symbol(:p, _subscript(p_id += 1))
+            Symbol(:p, _subscript(p_id += 1))
         end for i in eachindex(p0)
     ]
     tsym = [:t]

--- a/test/core/multiple_shooting.jl
+++ b/test/core/multiple_shooting.jl
@@ -140,10 +140,10 @@ end
         @test all(
             [
                 isapprox(
-                        sol_at_shooting_points.u[i],
-                        getproperty(ps, Symbol("interval_$i")).u0;
-                        atol = 1.0e-5,
-                    ) for i in 2:4
+                    sol_at_shooting_points.u[i],
+                    getproperty(ps, Symbol("interval_$i")).u0;
+                    atol = 1.0e-5,
+                ) for i in 2:4
             ]
         )
         trajectory, _ = layer(nothing, ps, st)


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `166e9c52577f`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos lib/CorleoneOED/src/multiexperiments.jl src/single_shooting.jl test/core/multiple_shooting.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary:          | Pass  Broken  Total     Time
Code quality (Aqua.jl) |   22       1     23  9m15.6s
Testing Corleone tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Local controls | 20 pass, 20 total
Precompile workload | 4 pass, 4 total
Generic layer interface | 8 pass, 8 total
Multiple shooting | 29 pass, 29 total
Testing Corleone tests passed
$ GROUP=CorleoneOED_Core ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total
CorleoneOED   |  180    180
```

`GROUP=CorleoneOED_QA` fails identically on this branch and clean base
`166e9c52577f`: 18 passed, 1 failed, and 1 was broken because four newly exported
Symbolics names are unapproved reexports. That clean-base regression was isolated with
failing-before/passing-after evidence in https://github.com/SciML/Corleone.jl/pull/140.

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- The CorleoneOED QA group remains blocked on the independent clean-base regression fixed by https://github.com/SciML/Corleone.jl/pull/140.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source and test diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
