### PR TITLE
Approve Symbolics 7.38 reexports in CorleoneOED QA

### DIFF
--- a/lib/CorleoneOED/test/qa/qa.jl
+++ b/lib/CorleoneOED/test/qa/qa.jl
@@ -18,7 +18,7 @@ const SYMBOLICS_REEXPORTS = (
     Symbol("@symstruct"), Symbol("@variables"), Symbol("@wrapped"), :BS, :Differential,
     :Equation, :IRStructure, :Inequality, :Integral, :Num, :Rewriters, :RuleSet, :SafeReal,
     :SymReal, :SymStruct, :SymbolicLinearODE, :SymbolicUtils, :Symbolics,
-    :SymbolicsSparsityDetector, :TreeReal, :approximation_function, :arguments,
+    :SymbolicsSparsityDetector, :TreeReal, :Unknown, :approximation_function, :arguments,
     :build_function, :expand, :expand_derivatives, :factors, :flatten_fractions,
     :gather_factor, :get_canonical_expr, :get_reachability, :getmetadata, :groebner_basis,
     :has_inverse, :has_left_inverse, :has_right_inverse, :hasmetadata, :ifelse_branching,
@@ -27,7 +27,8 @@ const SYMBOLICS_REEXPORTS = (
     :limit, :majorization_function, :minorization_function, :operation,
     :parse_expr_to_symbolic, :partial_frac_decomposition, :polynomial_coeffs,
     :populate_ir!, :print_ir, :quick_cancel, :right_continuous_function, :right_inverse,
-    :rootfunction, :semilinear_form, :semipolynomial_form, :semiquadratic_form, :series,
+    :rootfunction, :scalarize, :semilinear_form, :semipolynomial_form, :semiquadratic_form,
+    :series, :shape,
     :setmetadata, :simplify, :simplify_fractions, :solve_for, :solve_linear_ode_system,
     :solve_symbolic_IVP, :sorted_arguments, :substitute, :substitute_in_deriv,
     :substitute_in_deriv_and_depvar, :supremum, :symbolic_linear_solve, :symbolic_solve,
@@ -36,8 +37,8 @@ const SYMBOLICS_REEXPORTS = (
     :sympy_ode_solve, :sympy_pythoncall_algebraic_solve, :sympy_pythoncall_integrate,
     :sympy_pythoncall_limit, :sympy_pythoncall_linear_solve, :sympy_pythoncall_ode_solve,
     :sympy_pythoncall_simplify, :sympy_pythoncall_to_symbolics, :sympy_simplify,
-    :sympy_to_symbolics, :taylor, :taylor_coeff, :term, :terms, :tosymbol, :unwrap_const,
-    :vartype, Symbol("≲"), Symbol("≳"),
+    :sympy_to_symbolics, :taylor, :taylor_coeff, :term, :terms, :tosymbol, :unwrap,
+    :unwrap_const, :vartype, Symbol("≲"), Symbol("≳"),
 )
 run_qa(
     CorleoneOED;


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

Symbolics 7.38.0 replaced its broad SymbolicUtils reexport with an explicit, documented export list in https://github.com/JuliaSymbolics/Symbolics.jl/commit/de0731d6255be56bed82ebafa8d59243ea84e42f. That made `Unknown`, `scalarize`, `shape`, and `unwrap` newly visible through CorleoneOED's deliberate `@reexport using Symbolics` facade, so the strict reexport snapshot began rejecting them. This approves exactly those four dependency-owned exports; it changes no implementation or public definition.

## Verification

Failing before on clean `main` at `166e9c52577f136fa28badecd63f2e42c1543abc`, with Symbolics 7.39.0 (the current resolution permitted by the Symbolics 7.37 compat floor):

```console
$ GROUP=CorleoneOED_QA julia +release --project -e 'using Pkg; Pkg.test()'
No unapproved public reexports: Test Failed
  Evaluated: isempty([:Unknown, :scalarize, :shape, :unwrap])
Test Summary: | Pass  Fail  Broken  Total     Time
QA            |   18     1       1     20  1m07.8s
ERROR: Some tests did not pass: 18 passed, 1 failed, 0 errored, 1 broken.
```

Passing after with the same command and dependency resolution:

```console
Test Summary: | Pass  Broken  Total     Time
QA            |   19       1     20  1m06.5s
Testing CorleoneOED tests passed
Testing Corleone tests passed
```

The one `Broken` result is the existing `ei_broken = (:no_implicit_imports,)` declaration tracked at https://github.com/SciML/Corleone.jl/issues/103.

Relevant Core coverage also passed:

```console
$ GROUP=CorleoneOED_Core julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total
1D Example    |   36     36
Lotka Volterra | 125    125
Generic criterion interface | 2 2
Lotka Volterra SVD | 17 17
Testing CorleoneOED tests passed
Testing Corleone tests passed
```

Additional checks:

```console
$ julia +release --project=@runic -e 'using Runic; exit(Runic.main(["--check", "lib/CorleoneOED/test/qa/qa.jl"]))'
# exit 0
$ git diff --name-only -z upstream/main...HEAD | xargs -0 typos
# exit 0
$ git diff --check upstream/main...HEAD
# exit 0
```

After Corleone 0.0.8 and CorleoneOED 0.0.9 were released, current `main` also acquired independent stale group-environment self-compat constraints. Draft PR 143 fixes those constraints. To verify both focused fixes without combining their diffs, I composed current `main` + exact PR 143 patch + this unchanged reexport patch in a separate worktree and ran CorleoneOED QA:

```console
QA | Pass 19 Broken 1 Total 20
Testing CorleoneOED tests passed
```

Runic 1.10.0 now passes the whole repository after the separate formatter-only PR 139 merged. The reexport snapshot file also passes Runic 1.10.0 in isolation.

## Not verified / reviewer notes

- Against current `main`, the root test harness cannot reach CorleoneOED QA until the independent group self-compat fix in draft PR 143 lands. The exact composition described above passed.
- Documentation was not rebuilt because this changes only the existing QA approval snapshot and adds no public definition, docstring, docs file, or public behavior.
- Julia `pre`, downgrade, Examples, GPU, and downstream lanes were not run locally for this focused snapshot change.

Reviewer judgment: approving these four names preserves CorleoneOED's existing whole-Symbolics facade policy. A narrower public API would require a separate breaking API change rather than a QA-only patch.

## Links

- Symbolics export-list change: https://github.com/JuliaSymbolics/Symbolics.jl/commit/de0731d6255be56bed82ebafa8d59243ea84e42f
- Existing implicit-import tracking issue: https://github.com/SciML/Corleone.jl/issues/103
- Merged formatter-only fix: https://github.com/SciML/Corleone.jl/pull/139
- Group self-compat prerequisite: https://github.com/SciML/Corleone.jl/pull/143

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
