### PR TITLE
Release Corleone 0.0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Corleone"
 uuid = "2751e0db-33e9-4374-b36d-b7219e1e6b40"
 authors = ["Carl Julius Martensen <carl.martensen@ovgu.de>", "Christoph Plate <christoph.plate@ovgu.de>", "and contributors"]
-version = "0.0.8"
+version = "0.0.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Bumps `Corleone` 0.0.8 -> 0.0.9 (patch).

Source files changed since 0.0.8:
- `src/single_shooting.jl`

Commits:
- Fix group environment self-compat after releases (#143)
- Fix docs for Documenter 1.18 (#144)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
