### PR TITLE
Revert Corleone to 0.0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Corleone"
 uuid = "2751e0db-33e9-4374-b36d-b7219e1e6b40"
 authors = ["Carl Julius Martensen <carl.martensen@ovgu.de>", "Christoph Plate <christoph.plate@ovgu.de>", "and contributors"]
-version = "0.0.9"
+version = "0.0.8"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Reverts the version bump from https://github.com/SciML/Corleone.jl/pull/145.

On the `0.0.x` series every increment is a breaking change under Julia SemVer. AutoMerge rejected the registration for exactly that reason:

> This is a breaking change, but the release notes do not mention it.

This release pass was scoped to non-breaking updates, so the version returns to `0.0.8`. The `src/single_shooting.jl` change stays on master and should ship with a deliberate breaking release (0.0.9 or 0.1.0) whose notes call out the break.

Registry PR closed: https://github.com/JuliaRegistries/General/pull/167373

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R