### PR TITLE
Fix SingleShootingLayer Int index MethodError on 32-bit

### DIFF
--- a/src/local_controls.jl
+++ b/src/local_controls.jl
@@ -132,7 +132,7 @@ function get_subvector_indices(M::Int, L::Int)
     # Calculate the number of full-length vectors (N)
     N = floor(Int, M / L)
 
-    indices = Vector{UnitRange{Int64}}()
+    indices = Vector{UnitRange{Int}}()
 
     # Create the N full-length vectors
     for i in 1:N
@@ -152,12 +152,12 @@ function get_subvector_indices(M::Int, L::Int)
     return indices
 end
 
-function build_index_grid(controls::ControlParameter...; offset::Bool = true, tspan::Tuple = (-Inf, Inf), subdivide::Int64 = typemax(Int64))
+function build_index_grid(controls::ControlParameter...; offset::Bool = true, tspan::Tuple = (-Inf, Inf), subdivide::Int = typemax(Int))
     ts = map(controls) do ci
         get_timegrid(ci, tspan)
     end
     time_grid = vcat(reduce(vcat, ts), collect(tspan)) |> sort! |> unique! |> Base.Fix1(filter!, isfinite)
-    indices = zeros(Int64, length(ts), size(time_grid, 1) - 1)
+    indices = zeros(Int, length(ts), size(time_grid, 1) - 1)
     for i in axes(indices, 1), j in axes(indices, 2)
         indices[i, j] = clamp(
             searchsortedlast(ts[i], time_grid[j]),
@@ -186,7 +186,7 @@ end
 find_shooting_indices(tspan, control::ControlParameter) = any(first(tspan) .== control.t)
 
 
-function collect_tspans(controls::ControlParameter...; tspan = (-Inf, Inf), subdivide::Int64 = typemax(Int64))
+function collect_tspans(controls::ControlParameter...; tspan = (-Inf, Inf), subdivide::Int = typemax(Int))
     ts = map(controls) do ci
         get_timegrid(ci, tspan)
     end

--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -235,13 +235,13 @@ and per-stage sorted by states - parameters - controls
 """
 stage_ordered_shooting_constraints(traj::Trajectory) = deepvcat(traj.shooting)
 
-function collect_into!(res::AbstractVector, sval::SV, ind::Vector{Int64} = [0]) where {SV <: AbstractVector}
+function collect_into!(res::AbstractVector, sval::SV, ind::Vector{Int} = [0]) where {SV <: AbstractVector}
     for i in eachindex(sval)
         res[ind[1] += 1] = sval[i]
     end
     return
 end
-function collect_into!(res::AbstractVector, sval::NamedTuple, ind::Vector{Int64} = [0])
+function collect_into!(res::AbstractVector, sval::NamedTuple, ind::Vector{Int} = [0])
     for key in keys(sval)
         collect_into!(res, sval[key], ind)
     end
@@ -268,7 +268,7 @@ state_matchings(traj::Trajectory{S, U, P, T, SH}) where {S, U, P, T, SH <: Named
 parameter_matchings(traj::Trajectory{S, U, P, T, SH}) where {S, U, P, T, SH <: NamedTuple} = _matchings(traj, :p)
 control_matchings(traj::Trajectory{S, U, P, T, SH}) where {S, U, P, T, SH <: NamedTuple} = _matchings(traj, :controls)
 
-function _matchings!(res::AbstractVector, traj::Trajectory{S, U, P, T, SH}, kind::Symbol, ind::Vector{Int64} = [1]) where {S, U, P, T, SH <: NamedTuple}
+function _matchings!(res::AbstractVector, traj::Trajectory{S, U, P, T, SH}, kind::Symbol, ind::Vector{Int} = [1]) where {S, U, P, T, SH <: NamedTuple}
     for key in keys(traj.shooting)
         res[UnitRange(ind[1], (ind[1] += length(traj.shooting[key][kind])) - 1)] = traj.shooting[key][kind]
     end

--- a/src/node_initialization.jl
+++ b/src/node_initialization.jl
@@ -460,7 +460,7 @@ function (f::HybridInitialization)(rng::Random.AbstractRNG, layer::MultipleShoot
     forward_default = typeof(f.default_init) <: ForwardSolveInitialization
 
     any_forward = any(forward_involved) || forward_default
-    forward_vars = any(forward_involved) ? reduce(vcat, defined_vars[forward_involved]) : Int64[]
+    forward_vars = any(forward_involved) ? reduce(vcat, defined_vars[forward_involved]) : Int[]
 
     defined_vars = reduce(vcat, defined_vars)
     remaining_vars = [i for i in shooting_variables if i ∉ defined_vars]

--- a/src/single_shooting.jl
+++ b/src/single_shooting.jl
@@ -18,23 +18,23 @@ struct SingleShootingLayer{P, A, C, B, PB, SI, PI} <: LuxCore.AbstractLuxLayer
     "The algorithm with which `problem` is integrated."
     algorithm::A
     "Indices in parameters of `prob` corresponding to controls"
-    control_indices::Vector{Int64}
+    control_indices::Vector{Int}
     "The controls"
     controls::C
     "Indices of `prob.u0` which are degrees of freedom"
-    tunable_ic::Vector{Int64}
+    tunable_ic::Vector{Int}
     "Bounds on the tunable initial conditions of the problem"
     bounds_ic::B
     "Initialization of u"
     state_initialization::SI
     "Indices of `prob.p` which are degrees of freedom. This is derived from control_indices!"
-    tunable_p::Vector{Int64}
+    tunable_p::Vector{Int}
     "Bounds on the tunable parameters of the problem"
     bounds_p::PB
     "Initialization of p"
     parameter_initialization::PI
     "Indices of differential states that are quadratures, i.e. they do not enter into the right hand side of `problem`"
-    quadrature_indices::Vector{Int64}
+    quadrature_indices::Vector{Int}
 end
 
 function default_u0(
@@ -92,17 +92,17 @@ function SingleShootingLayer(
         prob,
         alg;
         controls = [],
-        tunable_ic = Int64[],
+        tunable_ic = Int[],
         bounds_ic = nothing,
         state_initialization = default_u0,
         bounds_p = nothing,
         parameter_initialization = default_p0,
-        quadrature_indices = Int64[],
+        quadrature_indices = Int[],
         kwargs...,
     )
     _prob = init_problem(remake(prob; kwargs...), alg)
     controls = collect(controls)
-    control_indices = isempty(controls) ? Int64[] : first.(controls)
+    control_indices = isempty(controls) ? Int[] : Int.(first.(controls))
     controls = isempty(controls) ? controls : last.(controls)
     u0 = prob.u0
     p_vec, _... = SciMLStructures.canonicalize(SciMLStructures.Tunable(), prob.p)
@@ -110,7 +110,7 @@ function SingleShootingLayer(
     p_vec = p_vec[tunable_p]
     ic_bounds = isnothing(bounds_ic) ? (to_val(u0, -Inf), to_val(u0, Inf)) : bounds_ic
     p_bounds = isnothing(bounds_p) ? (to_val(p_vec, -Inf), to_val(p_vec, Inf)) : bounds_p
-    quadrature_indices = isempty(quadrature_indices) ? Int64[] : collect(quadrature_indices)
+    quadrature_indices = isempty(quadrature_indices) ? Int[] : Int.(collect(quadrature_indices))
 
     @assert size(ic_bounds[1]) == size(ic_bounds[2]) == size(u0) "The size of the initial states and its bounds is inconsistent."
     @assert size(p_bounds[1]) == size(p_bounds[2]) == size(p_vec) "The size of the initial parameter vector and its bounds is inconsistent."
@@ -121,10 +121,10 @@ function SingleShootingLayer(
         alg,
         control_indices,
         controls,
-        tunable_ic,
+        Int.(tunable_ic),
         ic_bounds,
         state_initialization,
-        tunable_p,
+        Int.(tunable_p),
         p_bounds,
         parameter_initialization,
         quadrature_indices
@@ -277,8 +277,8 @@ function _retrieve_symbol_cache(xs, ps, t, idx)
 end
 
 struct InitialConditionRemaker <: Function
-    sorting::Vector{Int64}
-    constants::Vector{Int64}
+    sorting::Vector{Int}
+    constants::Vector{Int}
 end
 
 function (ic::InitialConditionRemaker)(
@@ -351,7 +351,7 @@ function __initialstates(
         grid = build_index_grid(controls...; tspan, subdivide = 100)
         tspans = collect_tspans(controls...; tspan, subdivide = 100)
     else
-        grid = Int64[i for i in control_indices]
+        grid = Int[i for i in control_indices]
         tspans = (problem.tspan,)
     end
     shooting_indices = zeros(Bool, size(u0, 1) + length(controls))
@@ -398,7 +398,7 @@ function (layer::SingleShootingLayer)(u0::AbstractArray, ps, st)
 end
 
 function build_optimal_control_solution(u, t, p, sys)
-    return Trajectory(sys, u, p, t, empty(u), Int64[])
+    return Trajectory(sys, u, p, t, empty(u), Int[])
 end
 
 sequential_solve(args...) = _sequential_solve(args...)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -18,7 +18,7 @@ struct Trajectory{S, U, P, T, SH}
     "The shooting values"
     shooting::SH
     "The shooting indices"
-    shooting_indices::Vector{Int64}
+    shooting_indices::Vector{Int}
 end
 
 SymbolicIndexingInterface.is_timeseries(::Type{<:Trajectory}) = Timeseries()


### PR DESCRIPTION
## Summary
- Index fields (`control_indices`, `tunable_ic`, …) were `Vector{Int64}`.
- On i686, `first.(controls)` yields `Int32`, so construction MethodErrors.
- Switch to native `Int` and coerce at the constructor boundary.

## Test plan
- [ ] Existing tests pass on x64
- [ ] x86 Core lane green

Made with [Cursor](https://cursor.com)