### PR TITLE
Release CorleoneOED 1.0.0 and OptimalControlBenchmarks 1.0.0

### DIFF
--- a/lib/CorleoneOED/Project.toml
+++ b/lib/CorleoneOED/Project.toml
@@ -1,7 +1,7 @@
 name = "CorleoneOED"
 uuid = "6590a4b1-d036-41fe-a5b4-03a980244101"
 authors = ["Christoph Plate", "Carl Julius Martensen", "Sebastian Sager"]
-version = "0.0.9"
+version = "1.0.0"
 
 [deps]
 Corleone = "2751e0db-33e9-4374-b36d-b7219e1e6b40"

--- a/lib/CorleoneOED/test/qa/Project.toml
+++ b/lib/CorleoneOED/test/qa/Project.toml
@@ -8,7 +8,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 Corleone = "0.0.8, 1"
-CorleoneOED = "0.0.9"
+CorleoneOED = "1"
 SciMLTesting = "2.6"
 Test = "1"
 julia = "1.10"

--- a/lib/OptimalControlBenchmarks/Project.toml
+++ b/lib/OptimalControlBenchmarks/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalControlBenchmarks"
 uuid = "d147904a-1eb9-11f1-01e7-bdf88e0f9445"
 authors = ["Robert Lampel", "Julius Martensen", "Christoph Plate", "Reinhold Wittmann"]
-version = "0.0.3"
+version = "1.0.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/lib/OptimalControlBenchmarks/test/qa/Project.toml
+++ b/lib/OptimalControlBenchmarks/test/qa/Project.toml
@@ -8,7 +8,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 Corleone = "0.0.6, 0.0.7, 0.0.8, 1"
-OptimalControlBenchmarks = "0.0.3"
+OptimalControlBenchmarks = "1"
 SciMLTesting = "2.6"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Takes both monorepo sublibraries to 1.0.0, following Corleone itself in #149.

| package | old | new | registry status |
|---|---|---|---|
| `CorleoneOED` | 0.0.9 | 1.0.0 | registered through 0.0.9 |
| `OptimalControlBenchmarks` | 0.0.3 | 1.0.0 | never registered |

## Why

Both sat in the `0.0.x` range, where every increment is breaking under Julia SemVer, so General AutoMerge rejects them without breaking-release notes. That is the same trap Corleone was stuck in at 0.0.8. Going to 1.0.0 gives each a normal release path again.

Neither package's source changes here. This is a version bump plus the compat repair it forces.

## Self-compat in the QA environments

`lib/CorleoneOED/test/qa/Project.toml` pinned `CorleoneOED = "0.0.9"` and `lib/OptimalControlBenchmarks/test/qa/Project.toml` pinned `OptimalControlBenchmarks = "0.0.3"`, each naming the old version of its own package. Left alone, both group environments become unsatisfiable the moment the version moves. Both now read `"1"`.

This is the breakage #143 fixed for an earlier release and that #149 hit again for the root package's `test/qa` and `test/examples` environments.

## Corleone compat left as is

Both sublibraries already read `Corleone = "0.0.6, 0.0.7, 0.0.8, 1"` after #149. Narrowing that to `"1"` would be defensible for a 1.0.0 pairing but is not required, and it would change downstream resolution, so it is left alone.

## What was not verified

No test suite was run locally. This PR changes four `Project.toml` files and no code.

Registration follow-up: `CorleoneOED` 1.0.0 is an ordinary new version. `OptimalControlBenchmarks` has never been in General, so publishing it would be a new-package registration rather than a version bump, which is a separate decision and is not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R